### PR TITLE
Cast Pandas Series object to NumPy array before image extraction

### DIFF
--- a/src/leopard_em/pydantic_models/particle_stack.py
+++ b/src/leopard_em/pydantic_models/particle_stack.py
@@ -164,8 +164,8 @@ class ParticleStack(BaseModel2DTM):
             img = load_mrc_image(img_path)
 
             # with reference to center pixel
-            pos_y = self._df.loc[indexes, "pos_y_img"]
-            pos_x = self._df.loc[indexes, "pos_x_img"]
+            pos_y = self._df.loc[indexes, "pos_y_img"].to_numpy()
+            pos_x = self._df.loc[indexes, "pos_x_img"].to_numpy()
             pos_y = torch.tensor(pos_y)
             pos_x = torch.tensor(pos_x)
 


### PR DESCRIPTION
Bug was found in the particle stack code where occasionally a pandas Series object would fail to convert to a torch.Tensor object. Here, the extracted columns are manually converted to numpy arrays before conversion into torch tensors