### PR TITLE
Resolve a circular import error

### DIFF
--- a/src/leopard_em/backend/core_refine_template.py
+++ b/src/leopard_em/backend/core_refine_template.py
@@ -13,7 +13,7 @@ from leopard_em.backend.core_match_template import (
 )
 from leopard_em.backend.utils import normalize_template_projection
 from leopard_em.utils.cross_correlation import handle_correlation_mode
-from leopard_em.utils.pre_processing import calculate_ctf_filter_stack
+from leopard_em.utils.filter_preprocessing import calculate_ctf_filter_stack
 
 # This is assuming the Euler angles are in the ZYZ intrinsic format
 # AND that the angles are ordered in (phi, theta, psi)

--- a/src/leopard_em/pydantic_models/match_template_manager.py
+++ b/src/leopard_em/pydantic_models/match_template_manager.py
@@ -18,7 +18,7 @@ from leopard_em.pydantic_models.optics_group import OpticsGroup
 from leopard_em.pydantic_models.orientation_search import OrientationSearchConfig
 from leopard_em.pydantic_models.types import BaseModel2DTM, ExcludedTensor
 from leopard_em.utils.data_io import load_mrc_image, load_mrc_volume
-from leopard_em.utils.pre_processing import calculate_ctf_filter_stack
+from leopard_em.utils.filter_preprocessing import calculate_ctf_filter_stack
 
 
 class MatchTemplateManager(BaseModel2DTM):

--- a/src/leopard_em/pydantic_models/particle_stack.py
+++ b/src/leopard_em/pydantic_models/particle_stack.py
@@ -219,8 +219,8 @@ class ParticleStack(BaseModel2DTM):
 
             # with reference to the exact pixel of the statistic (top-left)
             # need to account for relative extracted box size
-            pos_y = self._df.loc[indexes, "pos_y"]
-            pos_x = self._df.loc[indexes, "pos_x"]
+            pos_y = self._df.loc[indexes, "pos_y"].to_numpy()
+            pos_x = self._df.loc[indexes, "pos_x"].to_numpy()
             pos_y = torch.tensor(pos_y)
             pos_x = torch.tensor(pos_x)
             pos_y -= (H - h) // 2

--- a/src/leopard_em/utils/__init__.py
+++ b/src/leopard_em/utils/__init__.py
@@ -1,0 +1,31 @@
+"""Utilities submodule for various data and pre- and post-processing tasks."""
+
+from .cross_correlation import handle_correlation_mode
+from .data_io import (
+    load_mrc_image,
+    load_mrc_volume,
+    read_mrc_to_numpy,
+    read_mrc_to_tensor,
+    write_mrc_from_numpy,
+    write_mrc_from_tensor,
+)
+from .filter_preprocessing import (
+    Cs_to_pixel_size,
+    calculate_ctf_filter_stack,
+    get_Cs_range,
+)
+from .particle_stack import get_cropped_image_regions
+
+__all__ = [
+    "handle_correlation_mode",
+    "read_mrc_to_numpy",
+    "read_mrc_to_tensor",
+    "write_mrc_from_numpy",
+    "write_mrc_from_tensor",
+    "load_mrc_image",
+    "load_mrc_volume",
+    "get_cropped_image_regions",
+    "calculate_ctf_filter_stack",
+    "get_Cs_range",
+    "Cs_to_pixel_size",
+]


### PR DESCRIPTION
A circular import error existed between the refine template pydantic model and the utils.pre_processing module because there was a reference to the WhiteningFilterConfig object in both. Move the CTF filter pre-processing logic into its own utilities submodule.

Also to note the `do_image_preprocessing` function was not being called from anywhere, but it nevertheless should probably be referenced to reduce code duplication. Not sure if it makes sense to pass one of the pydantic models as input or determine the whitening filter beforehand and then pass it onto the helper pre-processing method.