### PR TITLE
fix: use `"top-left"` reference position as default

### DIFF
--- a/src/leopard_em/pydantic_models/data_structures/particle_stack.py
+++ b/src/leopard_em/pydantic_models/data_structures/particle_stack.py
@@ -311,7 +311,7 @@ class ParticleStack(BaseModel2DTM):
 
     def construct_image_stack(
         self,
-        pos_reference: Literal["center", "top-left"] = "center",
+        pos_reference: Literal["center", "top-left"] = "top-left",
         handle_bounds: Literal["pad", "error"] = "pad",
         padding_mode: Literal["constant", "reflect", "replicate"] = "constant",
         padding_value: float = 0.0,
@@ -325,9 +325,12 @@ class ParticleStack(BaseModel2DTM):
         Parameters
         ----------
         pos_reference : Literal["center", "top-left"], optional
-            The reference point for the positions, by default "center". If "center", the
-            boxes extracted will be image[y - box_size // 2 : y + box_size // 2, ...].
+            The reference point for the positions, by default "top-left". If "center",
+            the boxes extracted will be
+            image[y - box_size // 2 : y + box_size // 2, ...].
             If "top-left", the boxes will be image[y : y + box_size, ...].
+            Leopard-EM uses the "top-left" reference position, and unless you know data
+            was processed in a different way you should not change this value.
         handle_bounds : Literal["pad", "clip", "error"], optional
             How to handle the bounds of the image, by default "pad". If "pad", the image
             will be padded with the padding value based on the padding mode. If "error",
@@ -405,7 +408,7 @@ class ParticleStack(BaseModel2DTM):
             "theta",
             "phi",
         ],
-        pos_reference: Literal["center", "top-left"] = "center",
+        pos_reference: Literal["center", "top-left"] = "top-left",
         handle_bounds: Literal["pad", "error"] = "pad",
         padding_mode: Literal["constant", "reflect", "replicate"] = "constant",
         padding_value: float = 0.0,
@@ -421,9 +424,14 @@ class ParticleStack(BaseModel2DTM):
             "correlation_variance", "defocus", "psi", "theta", "phi"]
             The statistic to extract from the DataFrame.
         pos_reference : Literal["center", "top-left"], optional
-            The reference point for the positions, by default "center". If "center", the
-            boxes extracted will be image[y - box_size // 2 : y + box_size // 2, ...].
-            If "top-left", the boxes will be image[y : y + box_size, ...].
+            The reference point for the positions, by default "top-left". If "center",
+            the boxes extracted will be
+            image[y - (box_size - orig_template_size) // 2 :
+                  y + (box_size - orig_template_size // 2, ...].
+            If "top-left", the boxes will be
+            image[y : y + box_size - orig_template_size, ...].
+            Leopard-EM uses the "top-left" reference position, and unless you know data
+            was processed in a different way you should not change this value.
         handle_bounds : Literal["pad", "clip", "error"], optional
             How to handle the bounds of the image, by default "pad". If "pad", the image
             will be padded with the padding value based on the padding mode. If "error",
@@ -438,7 +446,6 @@ class ParticleStack(BaseModel2DTM):
         padding_value : float, optional
             The value to use for padding when `padding_mode` is "constant", by default
             0.0.
-
 
         Returns
         -------

--- a/src/leopard_em/pydantic_models/managers/constrained_search_manager.py
+++ b/src/leopard_em/pydantic_models/managers/constrained_search_manager.py
@@ -30,6 +30,11 @@ from leopard_em.utils.data_io import load_mrc_volume, load_template_tensor
 class ConstrainedSearchManager(BaseModel2DTM):
     """Model holding parameters necessary for running the constrained search program.
 
+    NOTE: The constrained search program should only be run on data from a single
+    reference micrograph. That is, if you have data from two or more micrographs, that
+    data from each micrograph needs processed separately. This restriction may be lifted
+    in the future.
+
     Attributes
     ----------
     template_volume_path : str
@@ -92,14 +97,22 @@ class ConstrainedSearchManager(BaseModel2DTM):
         self, prefer_refined_angles: bool = True
     ) -> dict[str, Any]:
         """Create the kwargs for the backend constrained_template core function."""
+        part_stk = self.particle_stack_reference
+
+        # Checks to make sure manager is properly configured
+        # pylint: disable=protected-access
+        assert part_stk._df["micrograph_path"].nunique() == 1, (
+            "Constrained search can only be run on data from a single micrograph. "
+            "Please ensure that the particle stack contains particles from only one "
+            "micrograph."
+        )
+
         device_list = self.computational_config.gpu_devices
 
         template = load_template_tensor(
             template_volume=self.template_volume,
             template_volume_path=self.template_volume_path,
         )
-
-        part_stk = self.particle_stack_reference
 
         euler_angles = part_stk.get_euler_angles(prefer_refined_angles)
 
@@ -145,7 +158,13 @@ class ConstrainedSearchManager(BaseModel2DTM):
         )
 
         # Ger corr mean and variance
-        # I want positions of reference but vals from constrained
+        # The position of the extracted areas needs to be from the larger particle, but
+        # the mean and variance must come from the initial match template on the
+        # smaller constrained particle.
+        # Currently, we just set the searched file (as in paths below) to the first
+        # element in the constrained particle stack.
+        # NOTE: This will *not* work if the constrained particle stack contains
+        # particles from multiple reference images.
         part_stk.set_column(
             "correlation_average_path",
             self.particle_stack_constrained["correlation_average_path"][0],
@@ -154,19 +173,22 @@ class ConstrainedSearchManager(BaseModel2DTM):
             "correlation_variance_path",
             self.particle_stack_constrained["correlation_variance_path"][0],
         )
+        # Get correlation statistics
         corr_mean_stack = part_stk.construct_cropped_statistic_stack(
-            "correlation_average"
+            stat="correlation_average",
+            pos_reference="top-left",
+            handle_bounds="pad",
+            padding_mode="constant",
+            padding_value=0.0,  # pad with zeros
         )
-        corr_std_stack = (
-            part_stk.construct_cropped_statistic_stack(
-                stat="correlation_variance",
-                pos_reference="center",
-                handle_bounds="pad",
-                padding_mode="constant",
-                padding_value=1e10,
-            )
-            ** 0.5
-        )  # var to std
+        corr_std_stack = part_stk.construct_cropped_statistic_stack(
+            stat="correlation_variance",
+            pos_reference="top-left",
+            handle_bounds="pad",
+            padding_mode="constant",
+            padding_value=1e10,  # large to avoid out of bound pixels having inf z-score
+        )
+        corr_std_stack = corr_std_stack**0.5  # Convert variance to standard deviation
 
         return {
             "particle_stack_dft": particle_images_dft,

--- a/src/leopard_em/pydantic_models/utils.py
+++ b/src/leopard_em/pydantic_models/utils.py
@@ -364,7 +364,7 @@ def setup_images_filters_particle_stack(
     """
     # Extract out the regions of interest (particles) based on the particle stack
     particle_images = particle_stack.construct_image_stack(
-        pos_reference="center",
+        pos_reference="top-left",
         padding_value=0.0,
         handle_bounds="pad",
         padding_mode="constant",
@@ -447,18 +447,20 @@ def setup_particle_backend_kwargs(
     """
     # Get correlation statistics
     corr_mean_stack = particle_stack.construct_cropped_statistic_stack(
-        "correlation_average",
+        stat="correlation_average",
+        pos_reference="top-left",
+        handle_bounds="pad",
+        padding_mode="constant",
+        padding_value=0.0,  # pad with zeros
     )
-    corr_std_stack = (
-        particle_stack.construct_cropped_statistic_stack(
-            stat="correlation_variance",
-            pos_reference="center",
-            handle_bounds="pad",
-            padding_mode="constant",
-            padding_value=1e10,  # large to avoid out of bound pixels having inf z-score
-        )
-        ** 0.5
-    )  # var to std
+    corr_std_stack = particle_stack.construct_cropped_statistic_stack(
+        stat="correlation_variance",
+        pos_reference="top-left",
+        handle_bounds="pad",
+        padding_mode="constant",
+        padding_value=1e10,  # large to avoid out of bound pixels having inf z-score
+    )
+    corr_std_stack = corr_std_stack**0.5  # Convert variance to standard deviation
 
     # Extract and preprocess images and filters
     (


### PR DESCRIPTION
Changes the default reference position to `"top-left"` when extracting regions out of images from template matching results (to match how the correlation mode is operating in Leopard-EM. See #52 for more information.

Closes #52 