### PR TITLE
Add back batched cross-correlation for `refine_template` program

### DIFF
--- a/docs/programs/refine_template.md
+++ b/docs/programs/refine_template.md
@@ -125,15 +125,23 @@ All these parameters are discussed in more detail on the [match template program
 
 ### Configuring GPUs for a match template run
 
-Template refinement can run across multiple GPUs and is controlled in the same way as match template.
-Note that the `num_cpus` field is currently unused for the refine template program and can just be set to one.
-Like [configuring GPUs for a match template run](match_template.md#configuring-gpus-for-a-match-template-run), GPUs are targeted by their device index.
+The refine template program parallelizes across multiple GPUs by splitting which particles are refined across the configured list of GPU devices.
+The `num_cpus` field controls how many concurrent streams of work are being submitted to each GPUs; in most cases, a value of `1` or `2` will saturate the GPU and give the best performance, although your mileage may vary.
+Like [configuring GPUs for a match template run](match_template.md#configuring-gpus-for-a-match-template-run), GPUs are targeted by their device index or the special string `"all"`
 The following configuration will run `refine_template` on GPU zero.
 
 ```yaml
 computational_config:
   gpu_ids: 0
   num_cpus: 1
+```
+
+The following configuration will run `refine_template` on all available GPUs with two streams per GPU.
+
+```yaml
+computational_config:
+  gpu_ids: "all"
+  num_cpus: 2
 ```
 
 ## Running the refine template program

--- a/src/leopard_em/backend/core_match_template.py
+++ b/src/leopard_em/backend/core_match_template.py
@@ -396,6 +396,10 @@ def _core_match_template_single_gpu(
     ### Setup iterator object with tqdm for progress bar ###
     ########################################################
 
+    total_projections = (
+        euler_angles.shape[0] * defocus_values.shape[0] * pixel_values.shape[0]
+    )
+
     num_batches = math.ceil(euler_angles.shape[0] / orientation_batch_size)
     orientation_batch_iterator = tqdm.tqdm(
         range(num_batches),
@@ -405,10 +409,9 @@ def _core_match_template_single_gpu(
         dynamic_ncols=True,
         position=device.index,
         mininterval=1,  # Slow down to reduce number of lines written
-    )
-
-    total_projections = (
-        euler_angles.shape[0] * defocus_values.shape[0] * pixel_values.shape[0]
+        smoothing=0.05,
+        unit="corr",
+        unit_scale=total_projections / num_batches,
     )
 
     ##################################

--- a/src/leopard_em/backend/core_match_template.py
+++ b/src/leopard_em/backend/core_match_template.py
@@ -475,9 +475,15 @@ def _do_streamed_orientation_cross_correlate(
     projective_filters: torch.Tensor,
     streams: list[torch.cuda.Stream],
 ) -> torch.Tensor:
-    """Batched projection and cross-correlation with fixed (batched) filters.
+    """Calculates a grid of 2D cross-correlations over multiple CUDA streams.
 
-    Note that this function returns a cross-correlogram with "same" mode (i.e. the
+    NOTE: This function is more performant than a batched 2D cross-correlation with
+    shape (N, H, W) when the kernel (template) is much smaller than the image (e.g.
+    kernel is 512x512 and image is 4096x4096). Each cross-correlation is computed
+    individually and stored in a batched tensor for the grid of orientations, defoci,
+    and pixel size values.
+
+    NOTE: this function returns a cross-correlogram with "same" mode (i.e. the
     same size as the input image). See numpy correlate docs for more information.
 
     Parameters
@@ -582,13 +588,13 @@ def _do_batched_orientation_cross_correlate(
 ) -> torch.Tensor:
     """Batched projection and cross-correlation with fixed (batched) filters.
 
-    Note that this function returns a cross-correlogram with "same" mode (i.e. the
-    same size as the input image). See numpy correlate docs for more information.
-
     NOTE: This function is similar to `_do_streamed_orientation_cross_correlate` but
     it computes cross-correlation batches over the orientation space. For example, if
     there are 32 orientations to process and 10 different defocus values, then there
     would be a total of 10 batched-32 cross-correlations computed.
+
+    NOTE: that this function returns a cross-correlogram with "same" mode (i.e. the
+    same size as the input image). See numpy correlate docs for more information.
 
     Parameters
     ----------

--- a/src/leopard_em/backend/core_match_template.py
+++ b/src/leopard_em/backend/core_match_template.py
@@ -10,19 +10,19 @@ from multiprocessing import set_start_method
 import roma
 import torch
 import tqdm
-from torch_fourier_slice import extract_central_slices_rfft_3d
 
+from leopard_em.backend.cross_correlation import (
+    do_streamed_orientation_cross_correlate,
+)
 from leopard_em.backend.process_results import (
     aggregate_distributed_results,
     scale_mip,
 )
 from leopard_em.backend.utils import (
-    do_iteration_statistics_updates,
-    normalize_template_projection,
+    do_iteration_statistics_updates_compiled,
     run_multiprocess_jobs,
 )
 
-COMPILE_BACKEND = "inductor"
 DEFAULT_STATISTIC_DTYPE = torch.float32
 
 # Turn off gradient calculations by default
@@ -30,13 +30,6 @@ torch.set_grad_enabled(False)
 
 # Set multiprocessing start method to spawn
 set_start_method("spawn", force=True)
-
-normalize_template_projection_compiled = torch.compile(
-    normalize_template_projection, backend=COMPILE_BACKEND
-)
-do_iteration_statistics_updates_compiled = torch.compile(
-    do_iteration_statistics_updates, backend=COMPILE_BACKEND
-)
 
 
 ###########################################################
@@ -426,7 +419,7 @@ def _core_match_template_single_gpu(
             "ZYZ", euler_angles_batch, degrees=True, device=device
         )
 
-        cross_correlation = _do_streamed_orientation_cross_correlate(
+        cross_correlation = do_streamed_orientation_cross_correlate(
             image_dft=image_dft,
             template_dft=template_dft,
             rotation_matrices=rot_matrix,
@@ -469,281 +462,3 @@ def _core_match_template_single_gpu(
     # Place the results in the shared multi-process manager dictionary so accessible
     # by the main process.
     result_dict[device_id] = result
-
-
-def _do_streamed_orientation_cross_correlate(
-    image_dft: torch.Tensor,
-    template_dft: torch.Tensor,
-    rotation_matrices: torch.Tensor,
-    projective_filters: torch.Tensor,
-    streams: list[torch.cuda.Stream],
-) -> torch.Tensor:
-    """Calculates a grid of 2D cross-correlations over multiple CUDA streams.
-
-    NOTE: This function is more performant than a batched 2D cross-correlation with
-    shape (N, H, W) when the kernel (template) is much smaller than the image (e.g.
-    kernel is 512x512 and image is 4096x4096). Each cross-correlation is computed
-    individually and stored in a batched tensor for the grid of orientations, defoci,
-    and pixel size values.
-
-    NOTE: this function returns a cross-correlogram with "same" mode (i.e. the
-    same size as the input image). See numpy correlate docs for more information.
-
-    Parameters
-    ----------
-    image_dft : torch.Tensor
-        Real-fourier transform (RFFT) of the image with large image filters
-        already applied. Has shape (H, W // 2 + 1).
-    template_dft : torch.Tensor
-        Real-fourier transform (RFFT) of the template volume to take Fourier
-        slices from. Has shape (l, h, w // 2 + 1) where (l, h, w) is the original
-        real-space shape of the template volume.
-    rotation_matrices : torch.Tensor
-        Rotation matrices to apply to the template volume. Has shape
-        (num_orientations, 3, 3).
-    projective_filters : torch.Tensor
-        Multiplied 'ctf_filters' with 'whitening_filter_template'. Has shape
-        (num_Cs, num_defocus, h, w // 2 + 1). Is RFFT and not fftshifted.
-    streams : list[torch.cuda.Stream]
-        List of CUDA streams to use for parallel computation. Each stream will
-        handle a separate cross-correlation.
-
-    Returns
-    -------
-    torch.Tensor
-        Cross-correlation of the image with the template volume for each
-        orientation and defocus value. Will have shape
-        (num_Cs, num_defocus, num_orientations, H, W).
-    """
-    # Accounting for RFFT shape
-    projection_shape_real = (template_dft.shape[1], template_dft.shape[2] * 2 - 2)
-    image_shape_real = (image_dft.shape[0], image_dft.shape[1] * 2 - 2)
-
-    num_orientations = rotation_matrices.shape[0]
-    num_Cs = projective_filters.shape[0]  # pylint: disable=invalid-name
-    num_defocus = projective_filters.shape[1]
-
-    cross_correlation = torch.empty(
-        size=(num_Cs, num_defocus, num_orientations, *image_shape_real),
-        dtype=DEFAULT_STATISTIC_DTYPE,
-        device=image_dft.device,
-    )
-
-    # Do a batched Fourier slice extraction for all the orientations at once.
-    fourier_slices = extract_central_slices_rfft_3d(
-        volume_rfft=template_dft,
-        image_shape=(projection_shape_real[0],) * 3,
-        rotation_matrices=rotation_matrices,
-    )
-    fourier_slices = torch.fft.ifftshift(fourier_slices, dim=(-2,))
-    fourier_slices[..., 0, 0] = 0 + 0j  # zero out the DC component (mean zero)
-    fourier_slices *= -1  # flip contrast
-
-    # Iterate over the orientations
-    for i in range(num_orientations):
-        fourier_slice = fourier_slices[i]
-
-        # Iterate over the different pixel sizes (Cs) and defocus values for this
-        # particular orientation
-        for j in range(num_defocus):
-            for k in range(num_Cs):
-                # Use a round-robin scheduling for the streams
-                job_idx = (i * num_defocus * num_Cs) + (j * num_Cs) + k
-                stream_idx = job_idx % len(streams)
-                stream = streams[stream_idx]
-
-                with torch.cuda.stream(stream):
-                    # Apply the projective filter and do template normalization
-                    fourier_slice_filtered = fourier_slice * projective_filters[k, j]
-                    projection = torch.fft.irfft2(fourier_slice_filtered)
-                    projection = torch.fft.ifftshift(projection, dim=(-2, -1))
-                    projection = normalize_template_projection_compiled(
-                        projection,
-                        projection_shape_real,
-                        image_shape_real,
-                    )
-
-                    # Padded forward Fourier transform for cross-correlation
-                    projection_dft = torch.fft.rfft2(projection, s=image_shape_real)
-                    projection_dft[0, 0] = 0 + 0j
-
-                    # Cross correlation step by element-wise multiplication
-                    projection_dft = image_dft * projection_dft.conj()
-                    torch.fft.irfft2(
-                        projection_dft,
-                        s=image_shape_real,
-                        out=cross_correlation[k, j, i],
-                    )
-
-    # Wait for all streams to finish
-    for stream in streams:
-        stream.synchronize()
-
-    # shape is (num_Cs, num_defocus, num_orientations, H, W)
-    return cross_correlation
-
-
-def _do_batched_orientation_cross_correlate(
-    image_dft: torch.Tensor,
-    template_dft: torch.Tensor,
-    rotation_matrices: torch.Tensor,
-    projective_filters: torch.Tensor,
-) -> torch.Tensor:
-    """Batched projection and cross-correlation with fixed (batched) filters.
-
-    NOTE: This function is similar to `_do_streamed_orientation_cross_correlate` but
-    it computes cross-correlation batches over the orientation space. For example, if
-    there are 32 orientations to process and 10 different defocus values, then there
-    would be a total of 10 batched-32 cross-correlations computed.
-
-    NOTE: that this function returns a cross-correlogram with "same" mode (i.e. the
-    same size as the input image). See numpy correlate docs for more information.
-
-    Parameters
-    ----------
-    image_dft : torch.Tensor
-        Real-fourier transform (RFFT) of the image with large image filters
-        already applied. Has shape (H, W // 2 + 1).
-    template_dft : torch.Tensor
-        Real-fourier transform (RFFT) of the template volume to take Fourier
-        slices from. Has shape (l, h, w // 2 + 1) where (l, h, w) is the original
-        real-space shape of the template volume.
-    rotation_matrices : torch.Tensor
-        Rotation matrices to apply to the template volume. Has shape
-        (num_orientations, 3, 3).
-    projective_filters : torch.Tensor
-        Multiplied 'ctf_filters' with 'whitening_filter_template'. Has shape
-        (num_Cs, num_defocus, h, w // 2 + 1). Is RFFT and not fftshifted.
-
-    Returns
-    -------
-    torch.Tensor
-        Cross-correlation of the image with the template volume for each
-        orientation and defocus value. Will have shape
-        (num_Cs, num_defocus, num_orientations, H, W).
-    """
-    # Accounting for RFFT shape
-    projection_shape_real = (template_dft.shape[1], template_dft.shape[2] * 2 - 2)
-    image_shape_real = (image_dft.shape[0], image_dft.shape[1] * 2 - 2)
-
-    num_Cs = projective_filters.shape[0]  # pylint: disable=invalid-name
-    num_defocus = projective_filters.shape[1]
-
-    cross_correlation = torch.empty(
-        size=(
-            num_Cs,
-            num_defocus,
-            rotation_matrices.shape[0],
-            *image_shape_real,
-        ),
-        dtype=DEFAULT_STATISTIC_DTYPE,
-        device=image_dft.device,
-    )
-
-    # Extract central slice(s) from the template volume
-    fourier_slice = extract_central_slices_rfft_3d(
-        volume_rfft=template_dft,
-        image_shape=(projection_shape_real[0],) * 3,  # NOTE: requires cubic template
-        rotation_matrices=rotation_matrices,
-    )
-    fourier_slice = torch.fft.ifftshift(fourier_slice, dim=(-2,))
-    fourier_slice[..., 0, 0] = 0 + 0j  # zero out the DC component (mean zero)
-    fourier_slice *= -1  # flip contrast
-
-    # Apply the projective filters on a new batch dimension
-    fourier_slice = fourier_slice[None, None, ...] * projective_filters[:, :, None, ...]
-
-    # Inverse Fourier transform into real space and normalize
-    projections = torch.fft.irfftn(fourier_slice, dim=(-2, -1))
-    projections = torch.fft.ifftshift(projections, dim=(-2, -1))
-    projections = normalize_template_projection_compiled(
-        projections,
-        projection_shape_real,
-        image_shape_real,
-    )
-
-    for j in range(num_defocus):
-        for k in range(num_Cs):
-            projections_dft = torch.fft.rfftn(
-                projections[k, j, ...], dim=(-2, -1), s=image_shape_real
-            )
-            projections_dft[..., 0, 0] = 0 + 0j
-
-            # Cross correlation step by element-wise multiplication
-            projections_dft = image_dft[None, ...] * projections_dft.conj()
-            torch.fft.irfftn(
-                projections_dft, dim=(-2, -1), out=cross_correlation[k, j, ...]
-            )
-
-    return cross_correlation
-
-
-def _do_batched_orientation_cross_correlate_cpu(
-    image_dft: torch.Tensor,
-    template_dft: torch.Tensor,
-    rotation_matrices: torch.Tensor,
-    projective_filters: torch.Tensor,
-) -> torch.Tensor:
-    """Same as `_do_streamed_orientation_cross_correlate` but on the CPU.
-
-    The only difference is that this function does not call into a compiled torch
-    function for normalization.
-
-    TODO: Figure out a better way to split up CPU/GPU functions while remaining
-    performant and not duplicating code.
-
-    Parameters
-    ----------
-    image_dft : torch.Tensor
-        Real-fourier transform (RFFT) of the image with large image filters
-        already applied. Has shape (H, W // 2 + 1).
-    template_dft : torch.Tensor
-        Real-fourier transform (RFFT) of the template volume to take Fourier
-        slices from. Has shape (l, h, w // 2 + 1).
-    rotation_matrices : torch.Tensor
-        Rotation matrices to apply to the template volume. Has shape
-        (orientations, 3, 3).
-    projective_filters : torch.Tensor
-        Multiplied 'ctf_filters' with 'whitening_filter_template'. Has shape
-        (defocus_batch, h, w // 2 + 1). Is RFFT and not fftshifted.
-
-    Returns
-    -------
-    torch.Tensor
-        Cross-correlation for the batch of orientations and defocus values.s
-    """
-    # Accounting for RFFT shape
-    projection_shape_real = (template_dft.shape[1], template_dft.shape[2] * 2 - 2)
-    image_shape_real = (image_dft.shape[0], image_dft.shape[1] * 2 - 2)
-
-    # Extract central slice(s) from the template volume
-    fourier_slice = extract_central_slices_rfft_3d(
-        volume_rfft=template_dft,
-        image_shape=(projection_shape_real[0],) * 3,  # NOTE: requires cubic template
-        rotation_matrices=rotation_matrices,
-    )
-    fourier_slice = torch.fft.ifftshift(fourier_slice, dim=(-2,))
-    fourier_slice[..., 0, 0] = 0 + 0j  # zero out the DC component (mean zero)
-    fourier_slice *= -1  # flip contrast
-
-    # Apply the projective filters on a new batch dimension
-    fourier_slice = fourier_slice[None, None, ...] * projective_filters[:, :, None, ...]
-
-    # Inverse Fourier transform into real space and normalize
-    projections = torch.fft.irfftn(fourier_slice, dim=(-2, -1))
-    projections = torch.fft.ifftshift(projections, dim=(-2, -1))
-    projections = normalize_template_projection(
-        projections,
-        projection_shape_real,
-        image_shape_real,
-    )
-
-    # Padded forward Fourier transform for cross-correlation
-    projections_dft = torch.fft.rfftn(projections, dim=(-2, -1), s=image_shape_real)
-    projections_dft[..., 0, 0] = 0 + 0j  # zero out the DC component (mean zero)
-
-    # Cross correlation step by element-wise multiplication
-    projections_dft = image_dft[None, None, None, ...] * projections_dft.conj()
-    cross_correlation = torch.fft.irfftn(projections_dft, dim=(-2, -1))
-
-    return cross_correlation

--- a/src/leopard_em/backend/core_refine_template.py
+++ b/src/leopard_em/backend/core_refine_template.py
@@ -12,8 +12,8 @@ import tqdm
 from torch_fourier_slice import extract_central_slices_rfft_3d
 
 from leopard_em.backend.core_match_template import (
-    _do_bached_orientation_cross_correlate,
-    _do_bached_orientation_cross_correlate_cpu,
+    _do_batched_orientation_cross_correlate,
+    _do_batched_orientation_cross_correlate_cpu,
 )
 from leopard_em.backend.utils import (
     normalize_template_projection,
@@ -60,8 +60,9 @@ def core_refine_template(
     corr_std: torch.Tensor,  # (N, H - h + 1, W - w + 1)
     ctf_kwargs: dict,
     projective_filters: torch.Tensor,  # (N, h, w)
-    device: torch.device | list[torch.device] = None,
-    batch_size: int = 64,
+    device: torch.device | list[torch.device],
+    batch_size: int = 32,
+    num_cuda_streams: int = 1,
 ) -> dict[str, torch.Tensor]:
     """Core function to refine orientations and defoci of a set of particles.
 
@@ -103,17 +104,15 @@ def core_refine_template(
     device : torch.device | list[torch.device], optional
         Device or list of devices to use for processing.
     batch_size : int, optional
-        The number of orientations to process at once. Default is 64.
+        The number of cross-correlations to process in one batch, defaults to 32.
+    num_cuda_streams : int, optional
+        Number of CUDA streams to use for parallel processing. Defaults to 1.
 
     Returns
     -------
     dict[str, torch.Tensor]
         Dictionary containing the refined parameters for all particles.
     """
-    # If no device specified, use the device  gpu 0
-    if device is None:
-        device = [torch.device("cuda:0")]
-
     # Convert single device to list for consistent handling
     if isinstance(device, torch.device):
         device = [device]
@@ -137,6 +136,7 @@ def core_refine_template(
         projective_filters=projective_filters,
         batch_size=batch_size,
         devices=device,
+        num_cuda_streams=num_cuda_streams,
     )
 
     results = run_multiprocess_jobs(
@@ -223,6 +223,7 @@ def construct_multi_gpu_refine_template_kwargs(
     projective_filters: torch.Tensor,
     batch_size: int,
     devices: list[torch.device],
+    num_cuda_streams: int,
 ) -> list[dict]:
     """Split particle stack between requested devices.
 
@@ -258,6 +259,8 @@ def construct_multi_gpu_refine_template_kwargs(
         Batch size for orientation processing.
     devices : list[torch.device]
         List of devices to split across.
+    num_cuda_streams : int
+        Number of CUDA streams to use per device.
 
     Returns
     -------
@@ -318,6 +321,7 @@ def construct_multi_gpu_refine_template_kwargs(
             "ctf_kwargs": ctf_kwargs,
             "projective_filters": device_projective_filters,
             "batch_size": batch_size,
+            "num_cuda_streams": num_cuda_streams,
         }
 
         kwargs_per_device.append(kwargs)
@@ -345,6 +349,7 @@ def _core_refine_template_single_gpu(
     ctf_kwargs: dict,
     projective_filters: torch.Tensor,
     batch_size: int,
+    num_cuda_streams: int = 1,
 ) -> None:
     """Run refine template on a subset of particles on a single GPU.
 
@@ -384,8 +389,12 @@ def _core_refine_template_single_gpu(
         Projective filters for particles in this subset.
     batch_size : int
         Batch size for orientation processing.
+    num_cuda_streams : int, optional
+        Number of CUDA streams to use for parallel processing. Defaults to 1.
     """
     device = particle_stack_dft.device
+    streams = [torch.cuda.Stream(device=device) for _ in range(num_cuda_streams)]
+
     num_particles, _, img_w = particle_stack_dft.shape
     _, _, template_w = template_dft.shape
     # account for RFFT
@@ -408,25 +417,28 @@ def _core_refine_template_single_gpu(
         particle_image_dft = particle_stack_dft[i]
         particle_index = int(particle_indices[i])  # Original particle index
 
-        refined_stats = _core_refine_template_single_thread(
-            particle_image_dft=particle_image_dft,
-            particle_index=particle_index,
-            template_dft=template_dft,
-            euler_angles=euler_angles[i, :],
-            euler_angle_offsets=euler_angle_offsets,
-            defocus_u=defocus_u[i],
-            defocus_v=defocus_v[i],
-            defocus_angle=defocus_angle[i],
-            defocus_offsets=defocus_offsets,
-            pixel_size_offsets=pixel_size_offsets,
-            ctf_kwargs=ctf_kwargs,
-            corr_mean=corr_mean[i],
-            corr_std=corr_std[i],
-            projective_filter=projective_filters[i],
-            orientation_batch_size=batch_size,
-            device_id=device_id,
-        )
-        refined_statistics.append(refined_stats)
+        # Distribute different particles across streams
+        stream = streams[i % num_cuda_streams]
+        with torch.cuda.stream(stream):
+            refined_stats = _core_refine_template_single_thread(
+                particle_image_dft=particle_image_dft,
+                particle_index=particle_index,
+                template_dft=template_dft,
+                euler_angles=euler_angles[i, :],
+                euler_angle_offsets=euler_angle_offsets,
+                defocus_u=defocus_u[i],
+                defocus_v=defocus_v[i],
+                defocus_angle=defocus_angle[i],
+                defocus_offsets=defocus_offsets,
+                pixel_size_offsets=pixel_size_offsets,
+                ctf_kwargs=ctf_kwargs,
+                corr_mean=corr_mean[i],
+                corr_std=corr_std[i],
+                projective_filter=projective_filters[i],
+                batch_size=batch_size,
+                device_id=device_id,
+            )
+            refined_statistics.append(refined_stats)
 
     # For each particle, calculate the new best orientation, defocus, and position
     refined_cross_correlation = torch.tensor(
@@ -519,7 +531,7 @@ def _core_refine_template_single_thread(
     corr_std: torch.Tensor,
     ctf_kwargs: dict,
     projective_filter: torch.Tensor,
-    orientation_batch_size: int = 32,
+    batch_size: int = 32,
     device_id: int = 0,
 ) -> dict[str, float | int]:
     """Run the single-threaded core refine template function.
@@ -557,7 +569,7 @@ def _core_refine_template_single_thread(
         Keyword arguments to pass to the CTF calculation function.
     projective_filter : torch.Tensor
         Projective filters to apply to the Fourier slice particle. Shape of (h, w).
-    orientation_batch_size : int, optional
+    batch_size : int, optional
         The number of orientations to cross-correlate at once. Default is 32.
     device_id : int, optional
         The ID of the device/process. Default is 0.
@@ -608,7 +620,7 @@ def _core_refine_template_single_thread(
     combined_projective_filter = projective_filter[None, None, ...] * ctf_filters
 
     # Iterate over the Euler angle offsets in batches
-    num_batches = math.ceil(euler_angle_offsets.shape[0] / orientation_batch_size)
+    num_batches = math.ceil(euler_angle_offsets.shape[0] / batch_size)
 
     tqdm_iter = tqdm.tqdm(
         range(num_batches),
@@ -619,8 +631,8 @@ def _core_refine_template_single_thread(
     )
 
     for i in tqdm_iter:
-        start_idx = i * orientation_batch_size
-        end_idx = min((i + 1) * orientation_batch_size, euler_angle_offsets.shape[0])
+        start_idx = i * batch_size
+        end_idx = min((i + 1) * batch_size, euler_angle_offsets.shape[0])
         euler_angle_offsets_batch = euler_angle_offsets[start_idx:end_idx]
         rot_matrix_batch = roma.euler_to_rotmat(
             EULER_ANGLE_FMT,
@@ -639,15 +651,14 @@ def _core_refine_template_single_thread(
         if particle_image_dft.device.type == "cuda":
             # NOTE: Here we are setting to only a single stream, but this can easily
             # be extended to multiple streams if needed.
-            cross_correlation = _do_bached_orientation_cross_correlate(
+            cross_correlation = _do_batched_orientation_cross_correlate(
                 image_dft=particle_image_dft,
                 template_dft=template_dft,
                 rotation_matrices=rot_matrix_batch,
                 projective_filters=combined_projective_filter,
-                streams=[torch.cuda.Stream(device=particle_image_dft.device)],
             )
         else:
-            cross_correlation = _do_bached_orientation_cross_correlate_cpu(
+            cross_correlation = _do_batched_orientation_cross_correlate_cpu(
                 image_dft=particle_image_dft,
                 template_dft=template_dft,
                 rotation_matrices=rot_matrix_batch,

--- a/src/leopard_em/backend/core_refine_template.py
+++ b/src/leopard_em/backend/core_refine_template.py
@@ -11,9 +11,9 @@ import torch
 import tqdm
 from torch_fourier_slice import extract_central_slices_rfft_3d
 
-from leopard_em.backend.core_match_template import (
-    _do_batched_orientation_cross_correlate,
-    _do_batched_orientation_cross_correlate_cpu,
+from leopard_em.backend.cross_correlation import (
+    do_batched_orientation_cross_correlate,
+    do_batched_orientation_cross_correlate_cpu,
 )
 from leopard_em.backend.utils import (
     normalize_template_projection,
@@ -658,14 +658,14 @@ def _core_refine_template_single_thread(
         if particle_image_dft.device.type == "cuda":
             # NOTE: Here we are setting to only a single stream, but this can easily
             # be extended to multiple streams if needed.
-            cross_correlation = _do_batched_orientation_cross_correlate(
+            cross_correlation = do_batched_orientation_cross_correlate(
                 image_dft=particle_image_dft,
                 template_dft=template_dft,
                 rotation_matrices=rot_matrix_batch,
                 projective_filters=combined_projective_filter,
             )
         else:
-            cross_correlation = _do_batched_orientation_cross_correlate_cpu(
+            cross_correlation = do_batched_orientation_cross_correlate_cpu(
                 image_dft=particle_image_dft,
                 template_dft=template_dft,
                 rotation_matrices=rot_matrix_batch,

--- a/src/leopard_em/backend/core_refine_template.py
+++ b/src/leopard_em/backend/core_refine_template.py
@@ -101,7 +101,7 @@ def core_refine_template(
         Keyword arguments to pass to the CTF calculation function.
     projective_filters : torch.Tensor
         Projective filters to apply to each Fourier slice particle. Shape of (N, h, w).
-    device : torch.device | list[torch.device], optional
+    device : torch.device | list[torch.device]
         Device or list of devices to use for processing.
     batch_size : int, optional
         The number of cross-correlations to process in one batch, defaults to 32.

--- a/src/leopard_em/backend/cross_correlation.py
+++ b/src/leopard_em/backend/cross_correlation.py
@@ -1,0 +1,287 @@
+"""File containing Fourier-slice based cross-correlation functions for 2DTM."""
+
+import torch
+from torch_fourier_slice import extract_central_slices_rfft_3d
+
+from leopard_em.backend.utils import (
+    normalize_template_projection,
+    normalize_template_projection_compiled,
+)
+
+
+def do_streamed_orientation_cross_correlate(
+    image_dft: torch.Tensor,
+    template_dft: torch.Tensor,
+    rotation_matrices: torch.Tensor,
+    projective_filters: torch.Tensor,
+    streams: list[torch.cuda.Stream],
+) -> torch.Tensor:
+    """Calculates a grid of 2D cross-correlations over multiple CUDA streams.
+
+    NOTE: This function is more performant than a batched 2D cross-correlation with
+    shape (N, H, W) when the kernel (template) is much smaller than the image (e.g.
+    kernel is 512x512 and image is 4096x4096). Each cross-correlation is computed
+    individually and stored in a batched tensor for the grid of orientations, defoci,
+    and pixel size values.
+
+    NOTE: this function returns a cross-correlogram with "same" mode (i.e. the
+    same size as the input image). See numpy correlate docs for more information.
+
+    Parameters
+    ----------
+    image_dft : torch.Tensor
+        Real-fourier transform (RFFT) of the image with large image filters
+        already applied. Has shape (H, W // 2 + 1).
+    template_dft : torch.Tensor
+        Real-fourier transform (RFFT) of the template volume to take Fourier
+        slices from. Has shape (l, h, w // 2 + 1) where (l, h, w) is the original
+        real-space shape of the template volume.
+    rotation_matrices : torch.Tensor
+        Rotation matrices to apply to the template volume. Has shape
+        (num_orientations, 3, 3).
+    projective_filters : torch.Tensor
+        Multiplied 'ctf_filters' with 'whitening_filter_template'. Has shape
+        (num_Cs, num_defocus, h, w // 2 + 1). Is RFFT and not fftshifted.
+    streams : list[torch.cuda.Stream]
+        List of CUDA streams to use for parallel computation. Each stream will
+        handle a separate cross-correlation.
+
+    Returns
+    -------
+    torch.Tensor
+        Cross-correlation of the image with the template volume for each
+        orientation and defocus value. Will have shape
+        (num_Cs, num_defocus, num_orientations, H, W).
+    """
+    # Accounting for RFFT shape
+    projection_shape_real = (template_dft.shape[1], template_dft.shape[2] * 2 - 2)
+    image_shape_real = (image_dft.shape[0], image_dft.shape[1] * 2 - 2)
+
+    num_orientations = rotation_matrices.shape[0]
+    num_Cs = projective_filters.shape[0]  # pylint: disable=invalid-name
+    num_defocus = projective_filters.shape[1]
+
+    cross_correlation = torch.empty(
+        size=(num_Cs, num_defocus, num_orientations, *image_shape_real),
+        dtype=image_dft.real.dtype,  # Deduce the real dtype from complex DFT
+        device=image_dft.device,
+    )
+
+    # Do a batched Fourier slice extraction for all the orientations at once.
+    fourier_slices = extract_central_slices_rfft_3d(
+        volume_rfft=template_dft,
+        image_shape=(projection_shape_real[0],) * 3,
+        rotation_matrices=rotation_matrices,
+    )
+    fourier_slices = torch.fft.ifftshift(fourier_slices, dim=(-2,))
+    fourier_slices[..., 0, 0] = 0 + 0j  # zero out the DC component (mean zero)
+    fourier_slices *= -1  # flip contrast
+
+    # Iterate over the orientations
+    for i in range(num_orientations):
+        fourier_slice = fourier_slices[i]
+
+        # Iterate over the different pixel sizes (Cs) and defocus values for this
+        # particular orientation
+        for j in range(num_defocus):
+            for k in range(num_Cs):
+                # Use a round-robin scheduling for the streams
+                job_idx = (i * num_defocus * num_Cs) + (j * num_Cs) + k
+                stream_idx = job_idx % len(streams)
+                stream = streams[stream_idx]
+
+                with torch.cuda.stream(stream):
+                    # Apply the projective filter and do template normalization
+                    fourier_slice_filtered = fourier_slice * projective_filters[k, j]
+                    projection = torch.fft.irfft2(fourier_slice_filtered)
+                    projection = torch.fft.ifftshift(projection, dim=(-2, -1))
+                    projection = normalize_template_projection_compiled(
+                        projection,
+                        projection_shape_real,
+                        image_shape_real,
+                    )
+
+                    # Padded forward Fourier transform for cross-correlation
+                    projection_dft = torch.fft.rfft2(projection, s=image_shape_real)
+                    projection_dft[0, 0] = 0 + 0j
+
+                    # Cross correlation step by element-wise multiplication
+                    projection_dft = image_dft * projection_dft.conj()
+                    torch.fft.irfft2(
+                        projection_dft,
+                        s=image_shape_real,
+                        out=cross_correlation[k, j, i],
+                    )
+
+    # Wait for all streams to finish
+    for stream in streams:
+        stream.synchronize()
+
+    # shape is (num_Cs, num_defocus, num_orientations, H, W)
+    return cross_correlation
+
+
+def do_batched_orientation_cross_correlate(
+    image_dft: torch.Tensor,
+    template_dft: torch.Tensor,
+    rotation_matrices: torch.Tensor,
+    projective_filters: torch.Tensor,
+) -> torch.Tensor:
+    """Batched projection and cross-correlation with fixed (batched) filters.
+
+    NOTE: This function is similar to `do_streamed_orientation_cross_correlate` but
+    it computes cross-correlation batches over the orientation space. For example, if
+    there are 32 orientations to process and 10 different defocus values, then there
+    would be a total of 10 batched-32 cross-correlations computed.
+
+    NOTE: that this function returns a cross-correlogram with "same" mode (i.e. the
+    same size as the input image). See numpy correlate docs for more information.
+
+    Parameters
+    ----------
+    image_dft : torch.Tensor
+        Real-fourier transform (RFFT) of the image with large image filters
+        already applied. Has shape (H, W // 2 + 1).
+    template_dft : torch.Tensor
+        Real-fourier transform (RFFT) of the template volume to take Fourier
+        slices from. Has shape (l, h, w // 2 + 1) where (l, h, w) is the original
+        real-space shape of the template volume.
+    rotation_matrices : torch.Tensor
+        Rotation matrices to apply to the template volume. Has shape
+        (num_orientations, 3, 3).
+    projective_filters : torch.Tensor
+        Multiplied 'ctf_filters' with 'whitening_filter_template'. Has shape
+        (num_Cs, num_defocus, h, w // 2 + 1). Is RFFT and not fftshifted.
+
+    Returns
+    -------
+    torch.Tensor
+        Cross-correlation of the image with the template volume for each
+        orientation and defocus value. Will have shape
+        (num_Cs, num_defocus, num_orientations, H, W).
+    """
+    # Accounting for RFFT shape
+    projection_shape_real = (template_dft.shape[1], template_dft.shape[2] * 2 - 2)
+    image_shape_real = (image_dft.shape[0], image_dft.shape[1] * 2 - 2)
+
+    num_Cs = projective_filters.shape[0]  # pylint: disable=invalid-name
+    num_defocus = projective_filters.shape[1]
+
+    cross_correlation = torch.empty(
+        size=(
+            num_Cs,
+            num_defocus,
+            rotation_matrices.shape[0],
+            *image_shape_real,
+        ),
+        dtype=image_dft.real.dtype,  # Deduce the real dtype from complex DFT
+        device=image_dft.device,
+    )
+
+    # Extract central slice(s) from the template volume
+    fourier_slice = extract_central_slices_rfft_3d(
+        volume_rfft=template_dft,
+        image_shape=(projection_shape_real[0],) * 3,  # NOTE: requires cubic template
+        rotation_matrices=rotation_matrices,
+    )
+    fourier_slice = torch.fft.ifftshift(fourier_slice, dim=(-2,))
+    fourier_slice[..., 0, 0] = 0 + 0j  # zero out the DC component (mean zero)
+    fourier_slice *= -1  # flip contrast
+
+    # Apply the projective filters on a new batch dimension
+    fourier_slice = fourier_slice[None, None, ...] * projective_filters[:, :, None, ...]
+
+    # Inverse Fourier transform into real space and normalize
+    projections = torch.fft.irfftn(fourier_slice, dim=(-2, -1))
+    projections = torch.fft.ifftshift(projections, dim=(-2, -1))
+    projections = normalize_template_projection_compiled(
+        projections,
+        projection_shape_real,
+        image_shape_real,
+    )
+
+    for j in range(num_defocus):
+        for k in range(num_Cs):
+            projections_dft = torch.fft.rfftn(
+                projections[k, j, ...], dim=(-2, -1), s=image_shape_real
+            )
+            projections_dft[..., 0, 0] = 0 + 0j
+
+            # Cross correlation step by element-wise multiplication
+            projections_dft = image_dft[None, ...] * projections_dft.conj()
+            torch.fft.irfftn(
+                projections_dft, dim=(-2, -1), out=cross_correlation[k, j, ...]
+            )
+
+    return cross_correlation
+
+
+def do_batched_orientation_cross_correlate_cpu(
+    image_dft: torch.Tensor,
+    template_dft: torch.Tensor,
+    rotation_matrices: torch.Tensor,
+    projective_filters: torch.Tensor,
+) -> torch.Tensor:
+    """Same as `do_streamed_orientation_cross_correlate` but on the CPU.
+
+    The only difference is that this function does not call into a compiled torch
+    function for normalization.
+
+    TODO: Figure out a better way to split up CPU/GPU functions while remaining
+    performant and not duplicating code.
+
+    Parameters
+    ----------
+    image_dft : torch.Tensor
+        Real-fourier transform (RFFT) of the image with large image filters
+        already applied. Has shape (H, W // 2 + 1).
+    template_dft : torch.Tensor
+        Real-fourier transform (RFFT) of the template volume to take Fourier
+        slices from. Has shape (l, h, w // 2 + 1).
+    rotation_matrices : torch.Tensor
+        Rotation matrices to apply to the template volume. Has shape
+        (orientations, 3, 3).
+    projective_filters : torch.Tensor
+        Multiplied 'ctf_filters' with 'whitening_filter_template'. Has shape
+        (defocus_batch, h, w // 2 + 1). Is RFFT and not fftshifted.
+
+    Returns
+    -------
+    torch.Tensor
+        Cross-correlation for the batch of orientations and defocus values.s
+    """
+    # Accounting for RFFT shape
+    projection_shape_real = (template_dft.shape[1], template_dft.shape[2] * 2 - 2)
+    image_shape_real = (image_dft.shape[0], image_dft.shape[1] * 2 - 2)
+
+    # Extract central slice(s) from the template volume
+    fourier_slice = extract_central_slices_rfft_3d(
+        volume_rfft=template_dft,
+        image_shape=(projection_shape_real[0],) * 3,  # NOTE: requires cubic template
+        rotation_matrices=rotation_matrices,
+    )
+    fourier_slice = torch.fft.ifftshift(fourier_slice, dim=(-2,))
+    fourier_slice[..., 0, 0] = 0 + 0j  # zero out the DC component (mean zero)
+    fourier_slice *= -1  # flip contrast
+
+    # Apply the projective filters on a new batch dimension
+    fourier_slice = fourier_slice[None, None, ...] * projective_filters[:, :, None, ...]
+
+    # Inverse Fourier transform into real space and normalize
+    projections = torch.fft.irfftn(fourier_slice, dim=(-2, -1))
+    projections = torch.fft.ifftshift(projections, dim=(-2, -1))
+    projections = normalize_template_projection(
+        projections,
+        projection_shape_real,
+        image_shape_real,
+    )
+
+    # Padded forward Fourier transform for cross-correlation
+    projections_dft = torch.fft.rfftn(projections, dim=(-2, -1), s=image_shape_real)
+    projections_dft[..., 0, 0] = 0 + 0j  # zero out the DC component (mean zero)
+
+    # Cross correlation step by element-wise multiplication
+    projections_dft = image_dft[None, None, None, ...] * projections_dft.conj()
+    cross_correlation = torch.fft.irfftn(projections_dft, dim=(-2, -1))
+
+    return cross_correlation

--- a/src/leopard_em/backend/cross_correlation.py
+++ b/src/leopard_em/backend/cross_correlation.py
@@ -9,6 +9,7 @@ from leopard_em.backend.utils import (
 )
 
 
+# pylint: disable=too-many-locals,E1102
 def do_streamed_orientation_cross_correlate(
     image_dft: torch.Tensor,
     template_dft: torch.Tensor,
@@ -121,6 +122,7 @@ def do_streamed_orientation_cross_correlate(
     return cross_correlation
 
 
+# pylint: disable=E1102
 def do_batched_orientation_cross_correlate(
     image_dft: torch.Tensor,
     template_dft: torch.Tensor,
@@ -216,6 +218,7 @@ def do_batched_orientation_cross_correlate(
     return cross_correlation
 
 
+# pylint: disable=E1102
 def do_batched_orientation_cross_correlate_cpu(
     image_dft: torch.Tensor,
     template_dft: torch.Tensor,

--- a/src/leopard_em/pydantic_models/data_structures/particle_stack.py
+++ b/src/leopard_em/pydantic_models/data_structures/particle_stack.py
@@ -412,8 +412,8 @@ class ParticleStack(BaseModel2DTM):
             :                |                                  |
             :                |            +=== box_w ===+       |
             :                |            |             |       |
-            :                |            |     ....    |
-            :           img_height        |(x, y).*.. box_h       |
+            :                |            |     ....    |       |
+            :           img_height        |(x, y).*.. box_h     |
             :                |            |     ....    |       |
             :                |            |             |       |
             :                |            +=============+       |
@@ -559,8 +559,8 @@ class ParticleStack(BaseModel2DTM):
 
         # Create an empty tensor to store the stat stack
         h, w = self.original_template_size
-        box_h, image_w = self.extracted_box_size
-        stat_stack = torch.zeros((self.num_particles, box_h - h + 1, image_w - w + 1))
+        box_h, box_w = self.extracted_box_size
+        stat_stack = torch.zeros((self.num_particles, box_h - h + 1, box_w - w + 1))
 
         # Find the indexes in the DataFrame that correspond to each unique stat map
         stat_index_groups = self._df.groupby(stat_col).groups
@@ -578,7 +578,7 @@ class ParticleStack(BaseModel2DTM):
             # by half the different of the original template shape and extracted box
             # so that the padding around the statistic peak is symmetric.
             pos_y -= (box_h - h) // 2
-            pos_x -= (image_w - w) // 2
+            pos_x -= (box_w - w) // 2
 
             pos_y = torch.tensor(pos_y)
             pos_x = torch.tensor(pos_x)
@@ -587,7 +587,7 @@ class ParticleStack(BaseModel2DTM):
                 stat_map,
                 pos_y,
                 pos_x,
-                (box_h - h + 1, image_w - w + 1),
+                (box_h - h + 1, box_w - w + 1),
                 pos_reference="top-left",
                 handle_bounds=handle_bounds,
                 padding_mode=padding_mode,

--- a/src/leopard_em/pydantic_models/data_structures/particle_stack.py
+++ b/src/leopard_em/pydantic_models/data_structures/particle_stack.py
@@ -68,11 +68,11 @@ def get_cropped_image_regions(
         The box extends from (y, x) to (y + height, x + width).
 
         Example:
-            :  (y, x) *----- width -----+
-            :         |                 |
-            :         |               height
-            :         |                 |
-            :         +-----------------+
+            :         (y, x) *------ width -----+
+            :                |                  |
+            :                |                height
+            :                |                  |
+            :                +------------------+
 
     Parameters
     ----------

--- a/src/leopard_em/pydantic_models/managers/constrained_search_manager.py
+++ b/src/leopard_em/pydantic_models/managers/constrained_search_manager.py
@@ -176,14 +176,12 @@ class ConstrainedSearchManager(BaseModel2DTM):
         # Get correlation statistics
         corr_mean_stack = part_stk.construct_cropped_statistic_stack(
             stat="correlation_average",
-            pos_reference="top-left",
             handle_bounds="pad",
             padding_mode="constant",
             padding_value=0.0,  # pad with zeros
         )
         corr_std_stack = part_stk.construct_cropped_statistic_stack(
             stat="correlation_variance",
-            pos_reference="top-left",
             handle_bounds="pad",
             padding_mode="constant",
             padding_value=1e10,  # large to avoid out of bound pixels having inf z-score

--- a/src/leopard_em/pydantic_models/managers/refine_template_manager.py
+++ b/src/leopard_em/pydantic_models/managers/refine_template_manager.py
@@ -49,7 +49,7 @@ class RefineTemplateManager(BaseModel2DTM):
         Initialize the refine template manager.
     make_backend_core_function_kwargs(self) -> dict[str, Any]
         Create the kwargs for the backend refine_template core function.
-    run_refine_template(self, correlation_batch_size: int = 64) -> None
+    run_refine_template(self, correlation_batch_size: int = 32) -> None
         Run the refine template program.
     """
 
@@ -137,7 +137,7 @@ class RefineTemplateManager(BaseModel2DTM):
         )
 
     def get_refine_result(
-        self, backend_kwargs: dict, correlation_batch_size: int = 64
+        self, backend_kwargs: dict, correlation_batch_size: int = 32
     ) -> dict[str, np.ndarray]:
         """Get refine template result.
 
@@ -146,7 +146,7 @@ class RefineTemplateManager(BaseModel2DTM):
         backend_kwargs : dict
             Keyword arguments for the backend processing
         correlation_batch_size : int
-            Number of orientations to process at once. Defaults to 64.
+            Number of orientations to process at once. Defaults to 32.
 
         Returns
         -------

--- a/src/leopard_em/pydantic_models/utils.py
+++ b/src/leopard_em/pydantic_models/utils.py
@@ -448,14 +448,12 @@ def setup_particle_backend_kwargs(
     # Get correlation statistics
     corr_mean_stack = particle_stack.construct_cropped_statistic_stack(
         stat="correlation_average",
-        pos_reference="top-left",
         handle_bounds="pad",
         padding_mode="constant",
         padding_value=0.0,  # pad with zeros
     )
     corr_std_stack = particle_stack.construct_cropped_statistic_stack(
         stat="correlation_variance",
-        pos_reference="top-left",
         handle_bounds="pad",
         padding_mode="constant",
         padding_value=1e10,  # large to avoid out of bound pixels having inf z-score

--- a/tests/pydantic_models/test_particle_stack.py
+++ b/tests/pydantic_models/test_particle_stack.py
@@ -296,12 +296,6 @@ def test_particle_stack_top_left_and_center_self_consistency():
     assert extracted_mips_tl.shape == (2, 3, 3)
     assert extracted_mips_center.shape == (2, 3, 3)
 
-    # DEBUG: Save these to numpy files
-    np.save("extracted_images_tl.npy", extracted_images_tl)
-    np.save("extracted_images_center.npy", extracted_images_center)
-    np.save("extracted_mips_tl.npy", extracted_mips_tl)
-    np.save("extracted_mips_center.npy", extracted_mips_center)
-
     # Check for self-consistency
     assert np.allclose(extracted_images_tl, extracted_images_center)
     assert np.allclose(extracted_mips_tl, extracted_mips_center)

--- a/tests/pydantic_models/test_particle_stack.py
+++ b/tests/pydantic_models/test_particle_stack.py
@@ -1,0 +1,319 @@
+import tempfile
+
+import mrcfile
+import numpy as np
+import pandas as pd
+import pytest
+
+from leopard_em.pydantic_models.data_structures.particle_stack import ParticleStack
+
+REQUIRED_COLUMNS = [
+    "particle_index",
+    "mip",
+    "scaled_mip",
+    "correlation_mean",
+    "correlation_variance",
+    "total_correlations",
+    "pos_x",
+    "pos_y",
+    "pos_x_img",
+    "pos_y_img",
+    "pos_x_img_angstrom",
+    "pos_y_img_angstrom",
+    "psi",
+    "theta",
+    "phi",
+    "relative_defocus",
+    "refined_relative_defocus",
+    "defocus_u",
+    "defocus_v",
+    "astigmatism_angle",
+    "pixel_size",
+    "refined_pixel_size",
+    "voltage",
+    "spherical_aberration",
+    "amplitude_contrast_ratio",
+    "phase_shift",
+    "ctf_B_factor",
+    "micrograph_path",
+    "template_path",
+    "mip_path",
+    "scaled_mip_path",
+    "psi_path",
+    "theta_path",
+    "phi_path",
+    "defocus_path",
+    "correlation_average_path",
+    "correlation_variance_path",
+]
+
+
+def make_minimal_df(num_rows=2):
+    """Create a minimal DataFrame with required columns for testing."""
+    data = {col: [0] * num_rows for col in REQUIRED_COLUMNS}
+    return pd.DataFrame(data)
+
+
+def make_reference_example_df(
+    position_reference: str = "top-left", rng=None
+) -> tuple[pd.DataFrame, np.ndarray, np.ndarray, float, float]:
+    """Create example data for particle extraction using position reference.
+
+    Parameters
+    ----------
+    position_reference : str
+        The position reference to use for the MIP. Can be 'top-left' or 'center'.
+    rng : np.random.Generator, optional
+        Random number generator for reproducibility. If None, uses default_rng.
+
+    Returns
+    -------
+    tuple[pd.DataFrame, np.ndarray, np.ndarray, float, float]
+        A tuple containing:
+        - DataFrame with particle data
+        - Image region 1 (ground truth) as a numpy array
+        - Image region 2 (ground truth) as a numpy array
+        - Value of MIP for region 1
+        - Value of MIP for region 2
+    """
+    if rng is None:
+        rng = np.random.default_rng()
+
+    df = make_minimal_df()
+    position_1 = (0, 0)
+    position_2 = (100, 100)
+    particle_shape = (32, 32)
+    image_shape = (256, 256)
+    correlation_shape = (
+        image_shape[0] - particle_shape[0] + 1,
+        image_shape[1] - particle_shape[1] + 1,
+    )
+
+    # Create test image and save to temporary file
+    region_1 = rng.normal(size=particle_shape).astype(np.float32)
+    region_2 = rng.normal(size=particle_shape).astype(np.float32)
+    image = np.zeros(image_shape, dtype=np.float32)
+    # Place the regions in the image
+    image[
+        position_1[1] : position_1[1] + region_1.shape[0],
+        position_1[0] : position_1[0] + region_1.shape[1],
+    ] = region_1
+    image[
+        position_2[1] : position_2[1] + region_2.shape[0],
+        position_2[0] : position_2[0] + region_2.shape[1],
+    ] = region_2
+    # Save to temporary mrc file
+    with tempfile.NamedTemporaryFile(suffix=".mrc", delete=False) as tmp_file:
+        mrcfile.new(tmp_file.name, data=image, overwrite=True)
+        mrc_path = tmp_file.name
+    # Set the micrograph path in the DataFrame
+    df["micrograph_path"] = mrc_path
+
+    # Create an example MIP statistic map
+    mip = np.zeros(correlation_shape, dtype=np.float32)
+    mip[position_1] = 10
+    mip[position_2] = 20
+
+    # Simulate extra padding for MIP if using center as position reference
+    if position_reference == "center":
+        # Center the MIP around the particle positions
+        mip = np.pad(
+            mip,
+            (
+                (particle_shape[0] // 2, particle_shape[0] // 2 + 1),
+                (particle_shape[1] // 2, particle_shape[1] // 2 + 1),
+            ),
+            mode="constant",
+            constant_values=0,
+        )
+        # Adjust the positions to match the center reference
+        position_1 = (
+            position_1[0] + particle_shape[1] // 2,
+            position_1[1] + particle_shape[0] // 2,
+        )
+        position_2 = (
+            position_2[0] + particle_shape[1] // 2,
+            position_2[1] + particle_shape[0] // 2,
+        )
+
+    # Save to temporary mrc file
+    with tempfile.NamedTemporaryFile(suffix=".mrc", delete=False) as tmp_file:
+        mrcfile.new(tmp_file.name, data=mip, overwrite=True)
+        mip_path = tmp_file.name
+    # Set the mip path in the DataFrame
+    df["mip_path"] = mip_path
+
+    # Only need to set the pos_x and pos_y columns as particle data
+    df["pos_x"] = [position_1[0], position_2[0]]
+    df["pos_y"] = [position_1[1], position_2[1]]
+
+    return df, region_1, region_2, 10, 20
+
+
+def test_particle_stack_init_and_load_df(tmp_path):
+    """Test initializing ParticleStack and loading DataFrame from CSV."""
+    df = make_minimal_df()
+    df_path = tmp_path / "particles.csv"
+    df.to_csv(df_path, index=False)
+
+    # Should initialize and load without error
+    ps = ParticleStack(
+        df_path=str(df_path),
+        extracted_box_size=(32, 32),
+        original_template_size=(16, 16),
+    )
+    assert isinstance(ps._df, pd.DataFrame)
+    assert set(REQUIRED_COLUMNS).issubset(ps._df.columns)
+    assert ps.extracted_box_size == (32, 32)
+    assert ps.original_template_size == (16, 16)
+
+
+def test_particle_stack_missing_columns(tmp_path):
+    """Test initializing ParticleStack with missing required columns."""
+    df = make_minimal_df()
+    df = df.drop(columns=["mip"])
+    df_path = tmp_path / "particles_missing.csv"
+    df.to_csv(df_path, index=False)
+
+    # Should raise ValueError for missing columns
+    with pytest.raises(ValueError) as excinfo:
+        ParticleStack(
+            df_path=str(df_path),
+            extracted_box_size=(32, 32),
+            original_template_size=(16, 16),
+        )
+    assert "Missing the following columns" in str(excinfo.value)
+
+
+def test_particle_stack_skip_df_load():
+    """Test initializing ParticleStack with skip_df_load=True."""
+    ps = ParticleStack(
+        df_path="not_a_real_file.csv",
+        extracted_box_size=(32, 32),
+        original_template_size=(16, 16),
+        skip_df_load=True,
+    )
+    # _df should not be set
+    assert not hasattr(ps, "_df")
+
+
+def test_particle_stack_image_extraction():
+    """Test that the image extraction works correctly for the ParticleStack."""
+    df, r1_ground_truth, r2_ground_truth, mip1, mip2 = make_reference_example_df()
+
+    # Add padding to the ground truth images to match the extraction box size
+    r1_ground_truth = np.pad(
+        r1_ground_truth, ((1, 1), (1, 1)), mode="constant", constant_values=0
+    )
+    r2_ground_truth = np.pad(
+        r2_ground_truth, ((1, 1), (1, 1)), mode="constant", constant_values=0
+    )
+
+    # Create ground truth MIP "images"
+    mip1_ground_truth = np.array([[0, 0, 0], [0, mip1, 0], [0, 0, 0]], dtype=np.float32)
+    mip2_ground_truth = np.array([[0, 0, 0], [0, mip2, 0], [0, 0, 0]], dtype=np.float32)
+
+    ps = ParticleStack(
+        df_path="",  # Setting data frame directly, so give empty path
+        extracted_box_size=(34, 34),  # This will give a correlation box size of 3x3
+        original_template_size=(32, 32),
+        skip_df_load=True,
+    )
+    ps._df = df  # Set the DataFrame directly
+
+    # Default is top-left reference, make sure it works itself
+    extracted_images = ps.construct_image_stack()
+    extracted_mips = ps.construct_cropped_statistic_stack(stat="mip")
+
+    assert extracted_images.shape == (2, 34, 34)
+    assert extracted_mips.shape == (2, 3, 3)
+
+    # Check the first image region
+    assert np.allclose(extracted_images[0], r1_ground_truth)
+    assert np.allclose(extracted_images[1], r2_ground_truth)
+
+    assert np.allclose(extracted_mips[0], mip1_ground_truth)
+    assert np.allclose(extracted_mips[1], mip2_ground_truth)
+
+
+def test_particle_stack_top_left_and_center_self_consistency():
+    """Ensure top-left and center position references are self-consistent."""
+    rng = np.random.default_rng(seed=42)
+    df_tl, r1_tl, r2_tl, mip1_tl, mip2_tl = make_reference_example_df(
+        position_reference="top-left",
+        rng=rng,
+    )
+    rng = np.random.default_rng(seed=42)
+    df_center, r1_center, r2_center, mip1_center, mip2_center = (
+        make_reference_example_df(
+            position_reference="center",
+            rng=rng,
+        )
+    )
+
+    # Add padding to the ground truth images to match the extraction box size
+    r1_tl = np.pad(r1_tl, ((1, 1), (1, 1)), mode="constant", constant_values=0)
+    r2_tl = np.pad(r2_tl, ((1, 1), (1, 1)), mode="constant", constant_values=0)
+    r1_center = np.pad(r1_center, ((1, 1), (1, 1)), mode="constant", constant_values=0)
+    r2_center = np.pad(r2_center, ((1, 1), (1, 1)), mode="constant", constant_values=0)
+    mip1_tl = np.array([[0, 0, 0], [0, mip1_tl, 0], [0, 0, 0]], dtype=np.float32)
+    mip2_tl = np.array([[0, 0, 0], [0, mip2_tl, 0], [0, 0, 0]], dtype=np.float32)
+    mip1_center = np.array(
+        [[0, 0, 0], [0, mip1_center, 0], [0, 0, 0]], dtype=np.float32
+    )
+    mip2_center = np.array(
+        [[0, 0, 0], [0, mip2_center, 0], [0, 0, 0]], dtype=np.float32
+    )
+
+    # Create ParticleStack instances for both references
+    ps_tl = ParticleStack(
+        df_path="",  # Setting data frame directly, so give empty path
+        extracted_box_size=(34, 34),  # This will give a correlation box size of 3x3
+        original_template_size=(32, 32),
+        skip_df_load=True,
+    )
+    ps_tl._df = df_tl  # Set the DataFrame directly
+
+    ps_center = ParticleStack(
+        df_path="",  # Setting data frame directly, so give empty path
+        extracted_box_size=(34, 34),  # This will give a correlation box size of 3x3
+        original_template_size=(32, 32),
+        skip_df_load=True,
+    )
+    ps_center._df = df_center  # Set the DataFrame directly
+
+    # Extract images and MIPs for both references
+    extracted_images_tl = ps_tl.construct_image_stack(pos_reference="top-left")
+    extracted_images_center = ps_center.construct_image_stack(pos_reference="center")
+
+    extracted_mips_tl = ps_tl.construct_cropped_statistic_stack(stat="mip")
+    extracted_mips_center = ps_center.construct_cropped_statistic_stack(stat="mip")
+
+    # Check shapes
+    assert extracted_images_tl.shape == (2, 34, 34)
+    assert extracted_images_center.shape == (2, 34, 34)
+
+    assert extracted_mips_tl.shape == (2, 3, 3)
+    assert extracted_mips_center.shape == (2, 3, 3)
+
+    # DEBUG: Save these to numpy files
+    np.save("extracted_images_tl.npy", extracted_images_tl)
+    np.save("extracted_images_center.npy", extracted_images_center)
+    np.save("extracted_mips_tl.npy", extracted_mips_tl)
+    np.save("extracted_mips_center.npy", extracted_mips_center)
+
+    # Check for self-consistency
+    assert np.allclose(extracted_images_tl, extracted_images_center)
+    assert np.allclose(extracted_mips_tl, extracted_mips_center)
+
+    # Check against ground truth image regions
+    assert np.allclose(extracted_images_tl[0], r1_tl)
+    assert np.allclose(extracted_images_tl[1], r2_tl)
+    assert np.allclose(extracted_images_center[0], r1_center)
+    assert np.allclose(extracted_images_center[1], r2_center)
+
+    # Check against ground truth MIPs
+    assert np.allclose(extracted_mips_tl[0], mip1_tl)
+    assert np.allclose(extracted_mips_tl[1], mip2_tl)
+    assert np.allclose(extracted_mips_center[0], mip1_center)
+    assert np.allclose(extracted_mips_center[1], mip2_center)

--- a/tests/self_consistency/test_backend_cross_correlate.py
+++ b/tests/self_consistency/test_backend_cross_correlate.py
@@ -1,0 +1,125 @@
+"""Testing script to check self-consistency of backend cross-correlation methods.
+
+We currently have three main methods for cross-correlation, each which perform better/
+worse depending on the specifics of the image shape, template shape, search space size,
+etc:
+  - _do_streamed_orientation_cross_correlate: Computes a grid of 2D cross-correlations
+    each over a different CUDA stream (all cross-correlations are 2D, but many
+    different correlations are computed).
+  - _do_batched_orientation_cross_correlate: Computes a grid of 2D cross-correlations
+    in sets of batches based on number of orientations all on the same CUDA stream.
+  - _do_batched_orientation_cross_correlate_cpu: CPU version of the batched
+    cross-correlation (does not use compiled torch functions).
+
+Although the execution model of these three methods are different, the should all return
+the same results for the same set of inputs. This test script generates some example
+data and compares the outputs of the three methods.
+"""
+
+import numpy as np
+import pytest
+import roma
+import torch
+from scipy.ndimage import gaussian_filter
+from torch_fourier_filter.ctf import calculate_ctf_2d
+
+from leopard_em.backend.core_match_template import (
+    _do_batched_orientation_cross_correlate,
+    _do_streamed_orientation_cross_correlate,
+)
+from leopard_em.pydantic_models.utils import get_cs_range
+
+IMAGE_SHAPE = (1024, 1024)
+TEMPLATE_SHAPE = (128, 128, 128)
+NUM_ORIENTATIONS = 10
+NUM_DEFOCUS_VALUES = 5
+NUM_PIXEL_SIZES = 4
+NUM_STREAMS = 1
+
+
+def smooth_random_noise(shape, sigma):
+    """
+    Generate a 3D smooth random noise array using Gaussian filtering.
+
+    Args:
+        shape (tuple): Shape of the output array, e.g., (D, H, W).
+        sigma (float or tuple): Standard deviation for Gaussian kernel.
+
+    Returns:
+        np.ndarray: Smoothed noise array of shape `shape`.
+    """
+    noise = np.random.randn(*shape)  # Raw white noise
+    smooth_noise = gaussian_filter(
+        noise, sigma=sigma, mode="reflect"
+    )  # Apply Gaussian smoothing
+    return smooth_noise
+
+
+@pytest.fixture
+def sample_input_data() -> dict[str, torch.Tensor]:
+    image = torch.randn(*IMAGE_SHAPE, dtype=torch.float32, device="cuda")
+    image /= (IMAGE_SHAPE[0] * IMAGE_SHAPE[1]) ** 0.5
+    template = smooth_random_noise(TEMPLATE_SHAPE, sigma=6.0)
+    template = torch.tensor(template, dtype=torch.float32, device="cuda")
+    rotation_matrices = roma.random_rotmat(size=NUM_ORIENTATIONS, device="cuda")
+
+    # FFT the image and template to prepare for cross-correlation
+    image_fft = torch.fft.rfft2(image)
+    template = torch.fft.fftshift(template, dim=(0, 1, 2))
+    template_fft = torch.fft.rfftn(template, dim=(0, 1, 2))
+    template_fft = torch.fft.fftshift(template_fft, dim=(0, 1))
+
+    # Generate a set of projective filters (CTFs) for the template
+    defocus_values = torch.linspace(500, 1500, NUM_DEFOCUS_VALUES)
+    pixel_sizes = torch.linspace(0.8, 1.2, NUM_PIXEL_SIZES)
+    cs_values = get_cs_range(1.0, pixel_sizes, 2.7)
+
+    ctf_list = []
+    for cs_val in cs_values:
+        tmp = calculate_ctf_2d(
+            defocus=defocus_values * 1e-4,  # Convert to um from Angstrom
+            astigmatism=200 * 1e-4,  # Convert to um from Angstrom
+            astigmatism_angle=0.0,
+            voltage=300,  # 300 kV
+            spherical_aberration=cs_val,
+            amplitude_contrast=0.07,
+            b_factor=100.0,
+            phase_shift=0.0,
+            pixel_size=1.0,
+            image_shape=template.shape[-2:],
+            rfft=True,
+            fftshift=False,
+        )
+        ctf_list.append(tmp)
+
+    projective_filters = torch.stack(ctf_list, dim=0).to(device="cuda")
+
+    return {
+        "image_dft": image_fft,
+        "template_dft": template_fft,
+        "rotation_matrices": rotation_matrices,
+        "projective_filters": projective_filters,
+    }
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA device not available")
+def test_stream_and_batch_cross_correlate_consistency(sample_input_data):
+    """Test that the streamed and batched cross-correlation methods return the same."""
+    cross_correlate_kwargs = sample_input_data
+
+    batched_result = _do_batched_orientation_cross_correlate(**cross_correlate_kwargs)
+    streamed_result = _do_streamed_orientation_cross_correlate(
+        streams=[torch.cuda.Stream() for _ in range(NUM_STREAMS)],
+        **cross_correlate_kwargs,
+    )
+
+    assert streamed_result.shape == batched_result.shape
+
+    max_abs_diff = (streamed_result - batched_result).abs().max().item()
+
+    # NOTE: using lighter tolerances here since FFT plans execute differently, and
+    # cross-correlation results should be distributed roughly normally around zero.
+    assert torch.allclose(streamed_result, batched_result, atol=5e-3, rtol=5e-3), (
+        f"Streamed and batched cross-correlation results not within tolerance.\n"
+        f"Max absolute difference: {max_abs_diff}\n"
+    )

--- a/tests/self_consistency/test_backend_cross_correlate.py
+++ b/tests/self_consistency/test_backend_cross_correlate.py
@@ -3,12 +3,12 @@
 We currently have three main methods for cross-correlation, each which perform better/
 worse depending on the specifics of the image shape, template shape, search space size,
 etc:
-  - _do_streamed_orientation_cross_correlate: Computes a grid of 2D cross-correlations
+  - do_streamed_orientation_cross_correlate: Computes a grid of 2D cross-correlations
     each over a different CUDA stream (all cross-correlations are 2D, but many
     different correlations are computed).
-  - _do_batched_orientation_cross_correlate: Computes a grid of 2D cross-correlations
+  - do_batched_orientation_cross_correlate: Computes a grid of 2D cross-correlations
     in sets of batches based on number of orientations all on the same CUDA stream.
-  - _do_batched_orientation_cross_correlate_cpu: CPU version of the batched
+  - do_batched_orientation_cross_correlate_cpu: CPU version of the batched
     cross-correlation (does not use compiled torch functions).
 
 Although the execution model of these three methods are different, the should all return
@@ -23,9 +23,9 @@ import torch
 from scipy.ndimage import gaussian_filter
 from torch_fourier_filter.ctf import calculate_ctf_2d
 
-from leopard_em.backend.core_match_template import (
-    _do_batched_orientation_cross_correlate,
-    _do_streamed_orientation_cross_correlate,
+from leopard_em.backend.cross_correlation import (
+    do_batched_orientation_cross_correlate,
+    do_streamed_orientation_cross_correlate,
 )
 from leopard_em.pydantic_models.utils import get_cs_range
 
@@ -107,8 +107,8 @@ def test_stream_and_batch_cross_correlate_consistency(sample_input_data):
     """Test that the streamed and batched cross-correlation methods return the same."""
     cross_correlate_kwargs = sample_input_data
 
-    batched_result = _do_batched_orientation_cross_correlate(**cross_correlate_kwargs)
-    streamed_result = _do_streamed_orientation_cross_correlate(
+    batched_result = do_batched_orientation_cross_correlate(**cross_correlate_kwargs)
+    streamed_result = do_streamed_orientation_cross_correlate(
         streams=[torch.cuda.Stream() for _ in range(NUM_STREAMS)],
         **cross_correlate_kwargs,
     )

--- a/tests/utils/test_crop_extraction.py
+++ b/tests/utils/test_crop_extraction.py
@@ -1,0 +1,351 @@
+"""Test the backed utility functions for box extraction from images."""
+
+import numpy as np
+import pytest
+import torch
+
+from leopard_em.pydantic_models.data_structures.particle_stack import (
+    _get_cropped_image_regions_numpy,
+    _get_cropped_image_regions_torch,
+    get_cropped_image_regions,
+)
+
+
+def get_test_patch(box_size: tuple[int, int]) -> np.ndarray:
+    """Create example data of ones with a two in the top-left corner of box size.
+
+    Parameters
+    ----------
+    box_size : tuple[int, int]
+        Size of the box to create, e.g., (32, 32).
+
+    Returns
+    -------
+    np.ndarray
+        A 2D array of ones with a two in the top-left corner.
+    """
+    patch = np.ones(box_size, dtype=np.float32)
+    patch[0, 0] = 2.0
+    return patch
+
+
+def test_get_cropped_image_regions_numpy_fixed_positions():
+    """Fixed positions test for _get_cropped_image_regions_numpy function."""
+    box_size = (5, 5)
+    pos_x = np.array([0, 64, 128])
+    pos_y = np.array([0, 100, 15])
+
+    # Create example image data for testing purposes
+    test_patch = get_test_patch(box_size)
+    image = np.zeros((256, 256), dtype=np.float32)
+    for x, y in zip(pos_x, pos_y):
+        image[y : y + box_size[0], x : x + box_size[1]] = test_patch
+
+    # Get cropped regions using the numpy implementation
+    cropped_regions = _get_cropped_image_regions_numpy(
+        image=image,
+        pos_y=pos_y,
+        pos_x=pos_x,
+        box_size=box_size,
+        handle_bounds="error",
+        padding_mode="constant",
+        padding_value=0.0,
+    )
+
+    ground_truth = np.stack([test_patch] * 3, axis=0)
+
+    assert cropped_regions.shape == (3, box_size[0], box_size[1])
+    assert np.allclose(cropped_regions, ground_truth)
+
+
+def test_get_cropped_image_regions_numpy_random_nonoverlapping():
+    """Random non-overlapping pos for _get_cropped_image_regions_numpy function."""
+    box_size = (5, 5)
+    num_patches = 10
+    image_size = (256, 256)
+    test_patch = get_test_patch(box_size)
+    image = np.zeros(image_size, dtype=np.float32)
+
+    # Generate non-overlapping positions
+    positions = []
+    for _ in range(num_patches):
+        while True:
+            y = np.random.randint(0, image_size[0] - box_size[0] + 1)
+            x = np.random.randint(0, image_size[1] - box_size[1] + 1)
+            if all(
+                not (y <= py < y + box_size[0] and x <= px < x + box_size[1])
+                for py, px in positions
+            ):
+                positions.append((y, x))
+                break
+
+    pos_y, pos_x = zip(*positions)
+
+    for x, y in zip(pos_x, pos_y):
+        image[y : y + box_size[0], x : x + box_size[1]] = test_patch
+
+    cropped_regions = _get_cropped_image_regions_numpy(
+        image=image,
+        pos_y=pos_y,
+        pos_x=pos_x,
+        box_size=box_size,
+        handle_bounds="error",
+        padding_mode="constant",
+        padding_value=0.0,
+    )
+
+    ground_truth = np.stack([test_patch] * num_patches, axis=0)
+
+    assert cropped_regions.shape == (num_patches, box_size[0], box_size[1])
+    assert np.allclose(cropped_regions, ground_truth)
+
+
+def test_get_cropped_image_regions_torch_fixed_positions():
+    """Fixed positions test for _get_cropped_image_regions_torch function."""
+    box_size = (5, 5)
+    pos_x = np.array([0, 64, 128])
+    pos_y = np.array([0, 100, 15])
+
+    test_patch = get_test_patch(box_size)
+    image = np.zeros((256, 256), dtype=np.float32)
+    for x, y in zip(pos_x, pos_y):
+        image[y : y + box_size[0], x : x + box_size[1]] = test_patch
+
+    image_tensor = torch.from_numpy(image)
+    pos_y_tensor = torch.from_numpy(pos_y)
+    pos_x_tensor = torch.from_numpy(pos_x)
+
+    cropped_regions = _get_cropped_image_regions_torch(
+        image=image_tensor,
+        pos_y=pos_y_tensor,
+        pos_x=pos_x_tensor,
+        box_size=box_size,
+        handle_bounds="error",
+        padding_mode="constant",
+        padding_value=0.0,
+    )
+
+    ground_truth = np.stack([test_patch] * 3, axis=0)
+    assert cropped_regions.shape == (3, box_size[0], box_size[1])
+    assert np.allclose(cropped_regions.numpy(), ground_truth)
+
+
+def test_get_cropped_image_regions_torch_random_nonoverlapping():
+    """Random non-overlapping pos  for _get_cropped_image_regions_torch function."""
+    box_size = (5, 5)
+    num_patches = 4
+    image_size = (256, 256)
+    test_patch = get_test_patch(box_size)
+    image = np.zeros(image_size, dtype=np.float32)
+
+    # Generate non-overlapping positions
+    positions = []
+    for _ in range(num_patches):
+        while True:
+            y = np.random.randint(0, image_size[0] - box_size[0] + 1)
+            x = np.random.randint(0, image_size[1] - box_size[1] + 1)
+            if all(
+                not (y <= py < y + box_size[0] and x <= px < x + box_size[1])
+                for py, px in positions
+            ):
+                positions.append((y, x))
+                break
+
+    pos_y, pos_x = zip(*positions)
+
+    for x, y in zip(pos_x, pos_y):
+        image[y : y + box_size[0], x : x + box_size[1]] = test_patch
+
+    image_tensor = torch.from_numpy(image)
+    pos_y_tensor = torch.tensor(pos_y)
+    pos_x_tensor = torch.tensor(pos_x)
+
+    cropped_regions = _get_cropped_image_regions_torch(
+        image=image_tensor,
+        pos_y=pos_y_tensor,
+        pos_x=pos_x_tensor,
+        box_size=box_size,
+        handle_bounds="error",
+        padding_mode="constant",
+        padding_value=0.0,
+    )
+
+    ground_truth = np.stack([test_patch] * num_patches, axis=0)
+    assert cropped_regions.shape == (num_patches, box_size[0], box_size[1])
+    assert np.allclose(cropped_regions.numpy(), ground_truth)
+
+
+def test_get_cropped_image_regions_defaults():
+    """Test for default parameters for the get_cropped_image_regions function."""
+    box_size = (5, 5)
+    pos_x = np.array([0, 64, 128])
+    pos_y = np.array([0, 100, 15])
+
+    test_patch = get_test_patch(box_size)
+    image = np.zeros((256, 256), dtype=np.float32)
+    for x, y in zip(pos_x, pos_y):
+        image[y : y + box_size[0], x : x + box_size[1]] = test_patch
+
+    cropped_regions = get_cropped_image_regions(
+        image=image,
+        pos_y=pos_y,
+        pos_x=pos_x,
+        box_size=box_size,
+    )
+
+    ground_truth = np.stack([test_patch] * 3, axis=0)
+
+    assert isinstance(cropped_regions, np.ndarray)
+    assert cropped_regions.shape == (3, box_size[0], box_size[1])
+    assert np.allclose(cropped_regions, ground_truth)
+
+
+def test_get_cropped_image_regions_center_top_left_consistency():
+    """Test that the center and top-left positions yield the same results."""
+    box_size = (5, 5)
+    pos_x = np.array([0, 64, 128])
+    pos_y = np.array([0, 100, 15])
+
+    test_patch = get_test_patch(box_size)
+    image = np.zeros((256, 256), dtype=np.float32)
+    for x, y in zip(pos_x, pos_y):
+        image[y : y + box_size[0], x : x + box_size[1]] = test_patch
+
+    cropped_regions_center = get_cropped_image_regions(
+        image=image,
+        pos_y=pos_y + box_size[0] // 2,
+        pos_x=pos_x + box_size[1] // 2,
+        box_size=box_size,
+        pos_reference="center",
+    )
+
+    cropped_regions_top_left = get_cropped_image_regions(
+        image=image,
+        pos_y=pos_y,
+        pos_x=pos_x,
+        box_size=box_size,
+        pos_reference="top-left",
+    )
+
+    assert np.allclose(cropped_regions_center, cropped_regions_top_left)
+
+
+def test_get_cropped_image_regions_edge_of_image_numpy():
+    """Test the edge cases (literally) for the get_cropped_image_regions function."""
+    # When handle_bounds is 'error', underlying function should raise an error
+    box_size = (5, 5)
+    pos_x = np.array([-1, 255])
+    pos_y = np.array([-1, 255])
+    image = np.ones((256, 256), dtype=np.float32)
+
+    # Test with handle_bounds='error' which should throw error
+    with pytest.raises(IndexError):
+        get_cropped_image_regions(
+            image=image,
+            pos_y=pos_y,
+            pos_x=pos_x,
+            box_size=box_size,
+            handle_bounds="error",
+            pos_reference="top-left",
+        )
+
+    # Test with padding of 0.0 which should
+    # 1. Not throw an error
+    # 2. Return with zeros in the padded areas
+    cropped_regions = get_cropped_image_regions(
+        image=image,
+        pos_y=pos_y,
+        pos_x=pos_x,
+        box_size=box_size,
+        handle_bounds="pad",
+        padding_mode="constant",
+        padding_value=0.0,
+        pos_reference="top-left",
+    )
+
+    ground_truth = np.ones((2, box_size[0], box_size[1]), dtype=np.float32)
+    # First case
+    ground_truth[0, :, 0] = 0  # Left edge padded with zeros
+    ground_truth[0, 0, :] = 0  # Top edge padded with zeros
+    # Second case
+    ground_truth[1, :, 1:] = 0  # Right edge padded with zeros
+    ground_truth[1, 1:, :] = 0  # Bottom edge padded with zeros
+
+    assert cropped_regions.shape == (2, box_size[0], box_size[1])
+    assert np.allclose(cropped_regions, ground_truth)
+
+    # Test with replicate padding
+    cropped_regions_replicate = get_cropped_image_regions(
+        image=image,
+        pos_y=pos_y,
+        pos_x=pos_x,
+        box_size=box_size,
+        handle_bounds="pad",
+        padding_mode="replicate",
+        padding_value=0.0,
+        pos_reference="top-left",
+    )
+    ground_truth_replicate = np.ones((2, box_size[0], box_size[1]), dtype=np.float32)
+
+    assert cropped_regions_replicate.shape == (2, box_size[0], box_size[1])
+    assert np.allclose(cropped_regions_replicate, ground_truth_replicate)
+
+
+def test_get_cropped_image_regions_edge_of_image_torch():
+    """Test the edge cases for the torch version of get_cropped_image_regions."""
+    box_size = (5, 5)
+    pos_x = np.array([-1, 255])
+    pos_y = np.array([-1, 255])
+    image = np.ones((256, 256), dtype=np.float32)
+
+    image_tensor = torch.from_numpy(image)
+    pos_x_tensor = torch.from_numpy(pos_x)
+    pos_y_tensor = torch.from_numpy(pos_y)
+
+    # Test with handle_bounds='error' which should throw error
+    with pytest.raises(IndexError):
+        get_cropped_image_regions(
+            image=image_tensor,
+            pos_y=pos_y_tensor,
+            pos_x=pos_x_tensor,
+            box_size=box_size,
+            handle_bounds="error",
+            pos_reference="top-left",
+        )
+
+    # Test with padding of 0.0
+    cropped_regions = get_cropped_image_regions(
+        image=image_tensor,
+        pos_y=pos_y_tensor,
+        pos_x=pos_x_tensor,
+        box_size=box_size,
+        handle_bounds="pad",
+        padding_mode="constant",
+        padding_value=0.0,
+        pos_reference="top-left",
+    )
+
+    ground_truth = np.ones((2, box_size[0], box_size[1]), dtype=np.float32)
+    ground_truth[0, :, 0] = 0  # Left edge padded with zeros
+    ground_truth[0, 0, :] = 0  # Top edge padded with zeros
+    ground_truth[1, :, 1:] = 0  # Right edge padded with zeros
+    ground_truth[1, 1:, :] = 0  # Bottom edge padded with zeros
+
+    assert cropped_regions.shape == (2, box_size[0], box_size[1])
+    assert np.allclose(cropped_regions.numpy(), ground_truth)
+
+    # Test with replicate padding
+    cropped_regions_replicate = get_cropped_image_regions(
+        image=image_tensor,
+        pos_y=pos_y_tensor,
+        pos_x=pos_x_tensor,
+        box_size=box_size,
+        handle_bounds="pad",
+        padding_mode="replicate",
+        padding_value=0.0,
+        pos_reference="top-left",
+    )
+    ground_truth_replicate = np.ones((2, box_size[0], box_size[1]), dtype=np.float32)
+
+    assert cropped_regions_replicate.shape == (2, box_size[0], box_size[1])
+    assert np.allclose(cropped_regions_replicate.numpy(), ground_truth_replicate)


### PR DESCRIPTION
Profiling the performance of cross-correlations with relatively similar sizes (e.g. template of 512x512 and image of 518x518) which are used in the `refine_template` program batched operations are more efficient. This pull request adds back in the `_do_batched_orientation_cross_correlate` function to the backend and renames the streamed version to `_do_streamed_orientation_cross_correlate`.

## Available execution methods

These two method have different execution behavior where the streamed version is approximately:
```python
for i in range(num_orientations):
    for j in range(num_defocus):
        for k in range(num_Cs):
            # compute single (H, W) cross correlation for index (k, j, i)
            ...
```

and the re-implemented batched version is now:
```python
# Input is b different rotation matrices
for j in range(num_defocus):
    for k in range(num_Cs):
        # compute batched (b, H, W) cross correlation for index (k, j)
        ...
```
The orientation batch size parameter for refine template now controls how many cross-correlations are computed at once, and the batch size is now independent of the number of pixel size and defocus value offsets searched over.

## Implemented self-consistency test

Both these functions should return the same corss-correlation tensor, and there is a new self-consistency test added to ensure that these two functions do indeed return the same values for a set of random input data.

## Other things wrapped up in this PR

Some slight tweaks to the tqdm iterators were made so units are correlations/sec for both match template and refine template. This way program performance can roughly be measured between different batch sizes and other search setups.

Also, some refactoring of the ParticleStack class was included to resolve box extraction  with different position references.

## Todo before merging

- [x] Add self-consistency test
- [x] Test the performance of the `refine_template` program
- [x] Update the documentation for the `refine_template` program
- [x] Test the `refine_template` program on real data to ensure results make sense.