### PR TITLE
Make position reference `"top-left"` consistent between the extracted image boxes and statistics

### DIFF
--- a/src/leopard_em/pydantic_models/data_structures/particle_stack.py
+++ b/src/leopard_em/pydantic_models/data_structures/particle_stack.py
@@ -309,6 +309,12 @@ class ParticleStack(BaseModel2DTM):
 
         self._df = tmp_df
 
+    def _get_position_reference_columns(self) -> tuple[str, str]:
+        """Get the position reference columns based on the DataFrame."""
+        y_col = "refined_pos_y" if "refined_pos_y" in self._df.columns else "pos_y"
+        x_col = "refined_pos_x" if "refined_pos_x" in self._df.columns else "pos_x"
+        return y_col, x_col
+
     def construct_image_stack(
         self,
         pos_reference: Literal["center", "top-left"] = "top-left",
@@ -354,8 +360,7 @@ class ParticleStack(BaseModel2DTM):
             The stack of images, this is the internal 'image_stack' attribute.
         """
         # Determine which position columns to use (refined if available)
-        y_col = "refined_pos_y" if "refined_pos_y" in self._df.columns else "pos_y"
-        x_col = "refined_pos_x" if "refined_pos_x" in self._df.columns else "pos_x"
+        y_col, x_col = self._get_position_reference_columns()
 
         # Create an empty tensor to store the image stack
         image_stack = torch.zeros((self.num_particles, *self.extracted_box_size))
@@ -457,9 +462,7 @@ class ParticleStack(BaseModel2DTM):
             the original template size.
         """
         stat_col = f"{stat}_path"
-        # Determine which position columns to use (refined if available)
-        y_col = "refined_pos_y" if "refined_pos_y" in self._df.columns else "pos_y"
-        x_col = "refined_pos_x" if "refined_pos_x" in self._df.columns else "pos_x"
+        y_col, x_col = self._get_position_reference_columns()
 
         if stat_col not in self._df.columns:
             raise ValueError(f"Statistic '{stat}' not found in the DataFrame.")


### PR DESCRIPTION
## Observations

When profiling the results from the `refine_template` program, nearly all of the peaks had their cross-correlation scores drop which suggests that the wrong portions of the images are being extracted or the particle orientations are wrong. Orientations are consistent with previous versions, so issue seemed to be with the image box extraction step.

This bug was introduces in #53 where the `"center"` position reference was erroneously changed to `"top-left"` during the particle stack setup phase. Changing the reference in this case will cause the extracted box to be asymmetrically padded which causes issues with correlation peak centering. Some of these peaks now fall outside the correlation window and thus the loss of cross-correlation scores. I've included a brief diagram below as a visual reference of what was happening.

![padding_modes_leopard_em](https://github.com/user-attachments/assets/fa97719b-f634-49db-9c62-f9308926a30f)

## Resolving reference inconsistencies

Combining the two different position references will likely cause issues down the road since users now have to think about two competing options if their data was processed in a different way (e.g. by cisTEM which has correlation peaks centered on the particle). This pull request changes how the image box extraction is happening with top-left reference so the boxes are symmetrically padded, and that data with center position references still work.

The top-left position which some underlying code uses for extraction now gets shifted by half the difference between the original template size and extracted box size. Correlation peaks from refine template now show up centered as expected.