### PR TITLE
calc b_factor env separately to ctf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "roma",
     "tqdm",
     "torch-fourier-slice>=v0.2.0",
-    "torch-fourier-filter>=v0.2.3",
+    "torch-fourier-filter>=v0.2.6",
     "torch-so3>=v0.2.0",
     "ttsim3d>=v0.4.0",
     "lmfit",

--- a/src/leopard_em/pydantic_models/utils.py
+++ b/src/leopard_em/pydantic_models/utils.py
@@ -167,7 +167,6 @@ def calculate_ctf_filter_stack_full_args(
             voltage=kwargs["voltage"],
             spherical_aberration=cs_val,
             amplitude_contrast=kwargs["amplitude_contrast_ratio"],
-            b_factor=0.0,
             phase_shift=kwargs["phase_shift"],
             pixel_size=kwargs["pixel_size"],
             image_shape=template_shape,


### PR DESCRIPTION
Future proofing for anticipated change to torch-fourier-filter.
Have not remove the B from the ctf call yet.