### PR TITLE
fix: Add proper stream synchronization in backend to prevent edge case

### DIFF
--- a/src/leopard_em/backend/cross_correlation.py
+++ b/src/leopard_em/backend/cross_correlation.py
@@ -80,7 +80,6 @@ def do_streamed_orientation_cross_correlate(
 
     # Barrier to ensure Fourier slice computation on default stream is done before
     # continuing computation in parallel on non-default streams.
-    for s in streams:
     default_stream = torch.cuda.default_stream(image_dft.device)
     for s in streams:
         s.wait_stream(default_stream)

--- a/src/leopard_em/backend/cross_correlation.py
+++ b/src/leopard_em/backend/cross_correlation.py
@@ -81,7 +81,9 @@ def do_streamed_orientation_cross_correlate(
     # Barrier to ensure Fourier slice computation on default stream is done before
     # continuing computation in parallel on non-default streams.
     for s in streams:
-        s.wait_stream(torch.cuda.default_stream(image_dft.device))
+    default_stream = torch.cuda.default_stream(image_dft.device)
+    for s in streams:
+        s.wait_stream(default_stream)
 
     # Iterate over the orientations
     for i in range(num_orientations):


### PR DESCRIPTION
Fixes edge case where Fourier slice logic running on default stream did not complete before non-default CUDA streams began normalization and cross-correlation computation. See this PyTorch documentation page for more details: https://docs.pytorch.org/docs/stable/notes/cuda.html#cuda-streams

Does not noticeably impact performance when running `match_template` on 4k x 4k images.