### PR TITLE
Distribute work over multiple GPUs with a shared work queue

### DIFF
--- a/src/leopard_em/backend/core_match_template.py
+++ b/src/leopard_em/backend/core_match_template.py
@@ -3,25 +3,21 @@
 # Following pylint error ignored because torc.fft.* is not recognized as callable
 # pylint: disable=E1102
 
-import math
 import warnings
 from multiprocessing import set_start_method
 
 import roma
 import torch
-import tqdm
 
 from leopard_em.backend.cross_correlation import (
     do_streamed_orientation_cross_correlate,
 )
+from leopard_em.backend.distributed import SharedWorkIndexQueue, run_multiprocess_jobs
 from leopard_em.backend.process_results import (
     aggregate_distributed_results,
     scale_mip,
 )
-from leopard_em.backend.utils import (
-    do_iteration_statistics_updates_compiled,
-    run_multiprocess_jobs,
-)
+from leopard_em.backend.utils import do_iteration_statistics_updates_compiled
 
 DEFAULT_STATISTIC_DTYPE = torch.float32
 
@@ -118,7 +114,6 @@ def core_match_template(
             - "correlation_sum": Sum of cross-correlation values for each pixel.
             - "correlation_squared_sum": Sum of squared cross-correlation values for
               each pixel.
-            - "total_projections": Total number of projections calculated.
             - "total_orientations": Total number of orientations searched.
             - "total_defocus": Total number of defocus values searched.
     """
@@ -159,24 +154,35 @@ def core_match_template(
 
     projective_filters = ctf_filters * whitening_filter_template[None, None, ...]
 
-    #########################################
-    ### Split orientations across devices ###
-    #########################################
+    ############################################################
+    ### Shared queue mechanism and multiprocessing arguments ###
+    ############################################################
 
     if isinstance(device, torch.device):
         device = [device]
 
-    kwargs_per_device = construct_multi_gpu_match_template_kwargs(
-        image_dft=image_dft,
-        template_dft=template_dft,
-        euler_angles=euler_angles,
-        projective_filters=projective_filters,
-        defocus_values=defocus_values,
-        pixel_values=pixel_values,
-        orientation_batch_size=orientation_batch_size,
-        num_cuda_streams=num_cuda_streams,
-        devices=device,
+    index_queue = SharedWorkIndexQueue(
+        total_indices=euler_angles.shape[0],
+        batch_size=orientation_batch_size,
+        prefetch_size=10,
     )
+
+    kwargs_per_device = []
+    for d in device:
+        kwargs = {
+            "index_queue": index_queue,
+            "image_dft": image_dft,
+            "template_dft": template_dft,
+            "euler_angles": euler_angles,
+            "projective_filters": projective_filters,
+            "defocus_values": defocus_values,
+            "pixel_values": pixel_values,
+            "orientation_batch_size": orientation_batch_size,
+            "num_cuda_streams": num_cuda_streams,
+            "device": d,
+        }
+
+        kwargs_per_device.append(kwargs)
 
     result_dict = run_multiprocess_jobs(
         target=_core_match_template_single_gpu,
@@ -193,8 +199,10 @@ def core_match_template(
     best_defocus = aggregated_results["best_defocus"]
     correlation_sum = aggregated_results["correlation_sum"]
     correlation_squared_sum = aggregated_results["correlation_squared_sum"]
-    total_projections = aggregated_results["total_projections"]
 
+    total_projections = (
+        euler_angles.shape[0] * defocus_values.shape[0] * pixel_values.shape[0]
+    )
     mip_scaled = torch.empty_like(mip)
     mip, mip_scaled, correlation_mean, correlation_variance = scale_mip(
         mip=mip,
@@ -219,80 +227,13 @@ def core_match_template(
     }
 
 
-def construct_multi_gpu_match_template_kwargs(
-    image_dft: torch.Tensor,
-    template_dft: torch.Tensor,
-    euler_angles: torch.Tensor,
-    projective_filters: torch.Tensor,
-    defocus_values: torch.Tensor,
-    pixel_values: torch.Tensor,
-    orientation_batch_size: int,
-    num_cuda_streams: int,
-    devices: list[torch.device],
-) -> list[dict[str, torch.Tensor | torch.device | int]]:
-    """Split orientations between requested devices.
-
-    See the `core_match_template` function for further descriptions of the
-    input parameters.
-
-    Parameters
-    ----------
-    image_dft : torch.Tensor
-        dft of image
-    template_dft : torch.Tensor
-        dft of template
-    euler_angles : torch.Tensor
-        euler angles to search
-    projective_filters : torch.Tensor
-        filters to apply to each projection
-    defocus_values : torch.Tensor
-        corresponding defocus values for each filter
-    pixel_values : torch.Tensor
-        corresponding pixel size values for each filter
-    orientation_batch_size : int
-        number of projections to calculate at once
-    num_cuda_streams : int
-        number of CUDA streams to use for parallelizing cross-correlation computation
-    devices : list[torch.device]
-        list of devices to split the orientations across
-
-    Returns
-    -------
-    list[dict[str, torch.Tensor | int]]
-        List of dictionaries containing the kwargs to call the single-GPU
-        function. Each index in the list corresponds to a different device,
-        and all tensors in the dictionary have been allocated to that device.
-    """
-    kwargs_per_device = []
-
-    # Split the euler angles across devices
-    euler_angles_split = euler_angles.chunk(len(devices))
-
-    for device, euler_angles_device in zip(devices, euler_angles_split):
-        # Allocate and construct the kwargs for this device
-        kwargs = {
-            "image_dft": image_dft,
-            "template_dft": template_dft,
-            "euler_angles": euler_angles_device,
-            "projective_filters": projective_filters,
-            "defocus_values": defocus_values,
-            "pixel_values": pixel_values,
-            "orientation_batch_size": orientation_batch_size,
-            "num_cuda_streams": num_cuda_streams,
-            "device": device,
-        }
-
-        kwargs_per_device.append(kwargs)
-
-    return kwargs_per_device
-
-
 # pylint: disable=too-many-locals
 # pylint: disable=too-many-arguments
 # pylint: disable=too-many-positional-arguments
 def _core_match_template_single_gpu(
     result_dict: dict,
     device_id: int,
+    index_queue: SharedWorkIndexQueue,
     image_dft: torch.Tensor,
     template_dft: torch.Tensor,
     euler_angles: torch.Tensor,
@@ -315,6 +256,9 @@ def _core_match_template_single_gpu(
     device_id : int
         ID of the device which computation is running on. Results will be stored
         in the dictionary with this key.
+    index_queue : SharedWorkIndexQueue
+        Torch multiprocessing object for retrieving the next batch of orientations to
+        process during the 2DTM search.
     image_dft : torch.Tensor
         Real-fourier transform (RFFT) of the image with large image filters
         already applied. Has shape (H, W // 2 + 1).
@@ -408,65 +352,50 @@ def _core_match_template_single_gpu(
         size=image_shape_real, dtype=DEFAULT_STATISTIC_DTYPE, device=device
     )
 
-    ########################################################
-    ### Setup iterator object with tqdm for progress bar ###
-    ########################################################
-
-    total_projections = (
-        euler_angles.shape[0] * defocus_values.shape[0] * pixel_values.shape[0]
-    )
-
-    num_batches = math.ceil(euler_angles.shape[0] / orientation_batch_size)
-    orientation_batch_iterator = tqdm.tqdm(
-        range(num_batches),
-        desc=f"Progress on device: {device.index}",
-        leave=True,
-        total=num_batches,
-        dynamic_ncols=True,
-        position=device.index,
-        mininterval=1,  # Slow down to reduce number of lines written
-        smoothing=0.02,
-        unit="corr",
-        unit_scale=int(total_projections / num_batches) + 1,
-    )
-
     ##################################
     ### Start the orientation loop ###
     ##################################
 
-    for i in orientation_batch_iterator:
-        euler_angles_batch = euler_angles[
-            i * orientation_batch_size : (i + 1) * orientation_batch_size
-        ]
-        rot_matrix = roma.euler_to_rotmat(
-            "ZYZ", euler_angles_batch, degrees=True, device=device
-        )
+    while True:
+        indices = index_queue.get_next_indices()
+        if indices is None:
+            break
 
-        cross_correlation = do_streamed_orientation_cross_correlate(
-            image_dft=image_dft,
-            template_dft=template_dft,
-            rotation_matrices=rot_matrix,
-            projective_filters=projective_filters,
-            streams=streams,
-        )
+        # Fetching more than orientation_batch_size, so need inner loop
+        start_idx, end_idx = indices
 
-        # Update the tracked statistics through compiled function
-        do_iteration_statistics_updates_compiled(
-            cross_correlation,
-            euler_angles_batch,
-            defocus_values,
-            pixel_values,
-            mip,
-            best_phi,
-            best_theta,
-            best_psi,
-            best_defocus,
-            best_pixel_size,
-            correlation_sum,
-            correlation_squared_sum,
-            image_shape_real[0],
-            image_shape_real[1],
-        )
+        for i in range(start_idx, end_idx, orientation_batch_size):
+            batch_end = min(i + orientation_batch_size, end_idx)
+            euler_angles_batch = euler_angles[i:batch_end]
+            rot_matrix = roma.euler_to_rotmat(
+                "ZYZ", euler_angles_batch, degrees=True, device=device
+            )
+
+            cross_correlation = do_streamed_orientation_cross_correlate(
+                image_dft=image_dft,
+                template_dft=template_dft,
+                rotation_matrices=rot_matrix,
+                projective_filters=projective_filters,
+                streams=streams,
+            )
+
+            # Update the tracked statistics through compiled function
+            do_iteration_statistics_updates_compiled(
+                cross_correlation,
+                euler_angles_batch,
+                defocus_values,
+                pixel_values,
+                mip,
+                best_phi,
+                best_theta,
+                best_psi,
+                best_defocus,
+                best_pixel_size,
+                correlation_sum,
+                correlation_squared_sum,
+                image_shape_real[0],
+                image_shape_real[1],
+            )
 
     # Synchronization barrier post-computation
     for stream in streams:
@@ -485,7 +414,6 @@ def _core_match_template_single_gpu(
         "best_pixel_size": best_pixel_size.cpu().numpy(),
         "correlation_sum": correlation_sum.cpu().numpy(),
         "correlation_squared_sum": correlation_squared_sum.cpu().numpy(),
-        "total_projections": total_projections,
     }
 
     # Place the results in the shared multi-process manager dictionary so accessible

--- a/src/leopard_em/backend/core_refine_template.py
+++ b/src/leopard_em/backend/core_refine_template.py
@@ -15,10 +15,8 @@ from leopard_em.backend.cross_correlation import (
     do_batched_orientation_cross_correlate,
     do_batched_orientation_cross_correlate_cpu,
 )
-from leopard_em.backend.utils import (
-    normalize_template_projection,
-    run_multiprocess_jobs,
-)
+from leopard_em.backend.distributed import run_multiprocess_jobs
+from leopard_em.backend.utils import normalize_template_projection
 from leopard_em.pydantic_models.utils import calculate_ctf_filter_stack_full_args
 from leopard_em.utils.cross_correlation import handle_correlation_mode
 

--- a/src/leopard_em/backend/distributed.py
+++ b/src/leopard_em/backend/distributed.py
@@ -1,0 +1,127 @@
+"""Utilities related to distributed computing for the backend functions."""
+
+from multiprocessing import Manager, Process
+from typing import Any, Callable, Optional
+
+import torch.multiprocessing as mp
+
+
+class SharedWorkIndexQueue:
+    """Simple queue class for managing a shared index counter tracking work.
+
+    Parameters
+    ----------
+    next_index : mp.Value
+        A shared integer value representing the next index to be processed.
+    total_indices : int
+        The total number of indices (work items) to be processed. Each index is
+        considered its own work item, and these items will generally batched together.
+    batch_size : int
+        The number of indices to be processed in each batch.
+    prefetch_size : int
+        The number of indices to prefetch for processing. Is a multiplicitive factor
+        for batch_size. For example, if batch_size is 10 and prefetch_size is 3, then
+        up to 30 indices will be prefetched for processing.
+    lock : mp.Lock
+        A multiprocessing lock to ensure thread-safe access to the shared index.
+    """
+
+    next_index: mp.Value
+    total_indices: int
+    batch_size: int
+    prefetch_size: int
+    lock: mp.Lock
+
+    def __init__(self, total_indices: int, batch_size: int, prefetch_size: int = 10):
+        self.next_index = mp.Value("i", 0)  # Shared counter
+        self.total_indices = total_indices
+        self.batch_size = batch_size
+        self.prefetch_size = prefetch_size
+        self.lock = mp.Lock()
+
+    def get_next_indices(self) -> Optional[tuple[int, int]]:
+        """Get the next set of indices to process returning None if all work is done."""
+        with self.lock:
+            start_idx = self.next_index.value
+            if start_idx >= self.total_indices:
+                return None
+
+            end_idx = min(
+                start_idx + self.batch_size * self.prefetch_size, self.total_indices
+            )
+            self.next_index.value = end_idx
+
+            return (start_idx, end_idx)
+
+    def get_progress(self) -> float:
+        """Get the current progress of the work queue as a fraction."""
+        with self.lock:
+            return float(self.next_index / self.total_indices)
+
+
+def run_multiprocess_jobs(
+    target: Callable,
+    kwargs_list: list[dict[str, Any]],
+    extra_args: tuple[Any, ...] = (),
+    extra_kwargs: Optional[dict[str, Any]] = None,
+) -> dict[Any, Any]:
+    """Helper function for running multiple processes on the same target function.
+
+    Spawns multiple processes to run the same target function with different keyword
+    arguments, aggregates results in a shared dictionary, and returns them.
+
+    Parameters
+    ----------
+    target : Callable
+        The function that each process will execute. It must accept at least two
+        positional arguments: a shared dict and a unique index.
+    kwargs_list : list[dict[str, Any]]
+        A list of dictionaries containing keyword arguments for each process.
+    extra_args : tuple[Any, ...], optional
+        Additional positional arguments to pass to the target (prepending the shared
+        parameters).
+    extra_kwargs : Optional[dict[str, Any]], optional
+        Additional common keyword arguments for all processes.
+
+    Returns
+    -------
+    dict[Any, Any]
+        Aggregated results stored in the shared dictionary.
+
+    Example
+    -------
+    ```
+    def worker_fn(result_dict, idx, param1, param2):
+        result_dict[idx] = param1 + param2
+
+
+    kwargs_per_process = [
+        {"param1": 1, "param2": 2},
+        {"param1": 3, "param2": 4},
+    ]
+    results = run_multiprocess_jobs(worker_fn, kwargs_per_process)
+    print(results)
+    # {0: 3, 1: 7}
+    ```
+    """
+    if extra_kwargs is None:
+        extra_kwargs = {}
+
+    # Manager object for shared result data as a dictionary
+    manager = Manager()
+    result_dict = manager.dict()
+    processes: list[Process] = []
+
+    for i, kwargs in enumerate(kwargs_list):
+        args = (*extra_args, result_dict, i)
+
+        # Merge per-process kwargs with common kwargs.
+        proc_kwargs = {**extra_kwargs, **kwargs}
+        p = Process(target=target, args=args, kwargs=proc_kwargs)
+        processes.append(p)
+        p.start()
+
+    for p in processes:
+        p.join()
+
+    return dict(result_dict)

--- a/src/leopard_em/backend/distributed.py
+++ b/src/leopard_em/backend/distributed.py
@@ -13,6 +13,12 @@ class SharedWorkIndexQueue:
     ----------
     next_index : mp.Value
         A shared integer value representing the next index to be processed.
+    process_counts : mp.Array
+        Shared counter array tracking how many pieces of work each individual process
+        has grabbed.
+    num_processes : int
+        The total number of processes grabbing work from this queue. Used as a way
+        to track how fast each process is grabbing work from the queue
     total_indices : int
         The total number of indices (work items) to be processed. Each index is
         considered its own work item, and these items will generally batched together.
@@ -27,36 +33,65 @@ class SharedWorkIndexQueue:
     """
 
     next_index: mp.Value
+    process_counts: mp.Array
+    num_processes: int
     total_indices: int
     batch_size: int
     prefetch_size: int
     lock: mp.Lock
 
-    def __init__(self, total_indices: int, batch_size: int, prefetch_size: int = 10):
+    def __init__(
+        self,
+        total_indices: int,
+        batch_size: int,
+        num_processes: int,
+        prefetch_size: int = 10,
+    ):
         self.next_index = mp.Value("i", 0)  # Shared counter
+        self.process_counts = mp.Array("i", [0] * num_processes)
+        self.num_processes = num_processes
         self.total_indices = total_indices
         self.batch_size = batch_size
         self.prefetch_size = prefetch_size
         self.lock = mp.Lock()
 
-    def get_next_indices(self) -> Optional[tuple[int, int]]:
-        """Get the next set of indices to process returning None if all work is done."""
+    def get_next_indices(
+        self, process_id: Optional[int] = None
+    ) -> Optional[tuple[int, int]]:
+        """Get the next set of indices to process returning None if all work is done.
+
+        Parameters
+        ----------
+        process_id: Optional[int]
+            Optional process index to use for updating the 'process_counts' array.
+            Default is None which corresponds to no update.
+        """
         with self.lock:
             start_idx = self.next_index.value
             if start_idx >= self.total_indices:
                 return None
 
+            # Do not go past total_indices
             end_idx = min(
                 start_idx + self.batch_size * self.prefetch_size, self.total_indices
             )
             self.next_index.value = end_idx
+
+            # Update the per-process counter
+            if process_id is not None:
+                self.process_counts[process_id] += end_idx - start_idx
 
             return (start_idx, end_idx)
 
     def get_current_index(self) -> int:
         """Get the current progress of the work queue (as an integer)."""
         with self.lock:
-            return self.next_index.value
+            return int(self.next_index.value)
+
+    def get_process_counts(self) -> list[int]:
+        """Get the number of indexes of work processed by each process."""
+        with self.lock:
+            return list(self.process_counts)
 
 
 def run_multiprocess_jobs(
@@ -64,7 +99,6 @@ def run_multiprocess_jobs(
     kwargs_list: list[dict[str, Any]],
     extra_args: tuple[Any, ...] = (),
     extra_kwargs: Optional[dict[str, Any]] = None,
-    track_tqdm_progress: bool = False,
     post_start_callback: Optional[Callable] = None,
 ) -> dict[Any, Any]:
     """Helper function for running multiple processes on the same target function.
@@ -84,7 +118,7 @@ def run_multiprocess_jobs(
         parameters).
     extra_kwargs : Optional[dict[str, Any]], optional
         Additional common keyword arguments for all processes.
-    post_start_callback Optional[Callable], optional
+    post_start_callback : Optional[Callable], optional
         Callback function to call after all processes have been started.
 
     Returns

--- a/src/leopard_em/backend/process_results.py
+++ b/src/leopard_em/backend/process_results.py
@@ -38,8 +38,7 @@ def aggregate_distributed_results(
         for result in results
     ]
 
-    # Find which device had the highest MIP for each pixel and index stats accordingly.
-    # Results after 'take_along_axis' have extra dimension at idx 0.
+    # Stack results from all devices into a single array. Dim 0 is device index
     mips = np.stack([result["mip"] for result in results], axis=0)
     best_phi = np.stack([result["best_phi"] for result in results], axis=0)
     best_theta = np.stack([result["best_theta"] for result in results], axis=0)
@@ -69,11 +68,6 @@ def aggregate_distributed_results(
         [result["correlation_squared_sum"] for result in results], axis=0
     ).sum(axis=0)
 
-    # NOTE: Currently only tracking total number of projections for statistics,
-    # but could be future case where number of projections calculated on each
-    # device is necessary for some statistical computation.
-    total_projections = sum(result["total_projections"] for result in results)
-
     # Cast back to torch tensors on the CPU
     mip_max = torch.from_numpy(mip_max)
     best_phi = torch.from_numpy(best_phi)
@@ -92,7 +86,6 @@ def aggregate_distributed_results(
         "best_defocus": best_defocus,
         "correlation_sum": correlation_sum,
         "correlation_squared_sum": correlation_squared_sum,
-        "total_projections": total_projections,
     }
 
 


### PR DESCRIPTION
Closes #79 

**Note**: This introduces some non-determinism into the match template backend function because of the following reasons:

- Previously orientations were split evenly between each GPU, that is, each GPU got exactly the same orientations for two template matching runs.
- [`torch.Tensor.max`](https://docs.pytorch.org/docs/stable/generated/torch.max.html) will return the first index of a maximum when there are multiple maxima
- When correlation values between two search positions are indistinguishable (up to floating point precision), then the first processed value will always win out.
- Exact ordering and distribution of work between devices will always yield the same results.

But now we don't have this strong ordering
- Shared work queue has no guarantees on orientation processing order on each device _when using multiple devices_.
- Maximum / argmaximum operation is no longer associative _when correlation values are the same_.
- MIP results will always be consistent with old behavior, but the "best" orientations and defocus values _only at these degeneracies_ are not always the same.

This is not a major issue under most reasonable circumstances. True peak values are high enough above the noise floor to not get "washed out" by randomness, and only regions with low correlation values should be affected. Before, these search positions would also be indistinguishable, but the ordering of the search and operations made it so this was never seen.

Should add a caveat to the match template results documentation page describing this behavior. Really will only affect developers comparing results exactly, for example in unit tests.