### PR TITLE
Speed up cross-correlation step by decomposed 2D FFT

### DIFF
--- a/src/leopard_em/backend/cross_correlation.py
+++ b/src/leopard_em/backend/cross_correlation.py
@@ -108,8 +108,16 @@ def do_streamed_orientation_cross_correlate(
                         image_shape_real,
                     )
 
-                    # Padded forward Fourier transform for cross-correlation
-                    projection_dft = torch.fft.rfft2(projection, s=image_shape_real)
+                    # NOTE: Decomposing 2D FFT into component 1D FFTs. Saves on first
+                    # pass where many lines are zeros. Approx 6-8% speedup.
+                    temp_fft = torch.fft.rfft(projection, n=image_shape_real[1], dim=-1)
+                    projection_dft = torch.fft.fft(
+                        temp_fft, n=image_shape_real[0], dim=-2
+                    )
+
+                    # # Padded forward Fourier transform for cross-correlation
+                    # projection_dft = torch.fft.rfft2(projection, s=image_shape_real)
+
                     projection_dft[0, 0] = 0 + 0j
 
                     # Cross correlation step by element-wise multiplication


### PR DESCRIPTION
Split the 2D real-to-complex Fast Fourier Transform step in the core cross-correlation backend into two individual FFT steps, a padded 1D real-to-complex transform and another padded 1D complex-to-complex transform. Gives a roughly 6.7% speedup on the benchmarking script with a 4,096 x 4,096 image and a 512 cube template.