### PR TITLE
Allow choice of streamed or batched backend for match template

### DIFF
--- a/src/leopard_em/backend/core_match_template_distributed.py
+++ b/src/leopard_em/backend/core_match_template_distributed.py
@@ -358,6 +358,7 @@ def core_match_template_distributed(
     device: torch.device,
     orientation_batch_size: int = 1,
     num_cuda_streams: int = 1,
+    backend: str | None = None,
     **kwargs: dict,
 ) -> dict[str, torch.Tensor]:
     """Distributed multi-node core function for the match template program.
@@ -377,6 +378,9 @@ def core_match_template_distributed(
     num_cuda_streams : int, optional
         Number of CUDA streams to use for overlapping data transfers and
         computation, by default 1.
+    backend : str, optional
+        The backend to use for computation. Defaults to None. Must be 'streamed' or
+        'batched'. If None, the default backend will be chosen.
     **kwargs : dict[str, torch.Tensor]
         Additional keyword arguments passed to the single-GPU core function. For the
         zeroth rank this should be a dictionary of Tensor objects with the following
@@ -462,6 +466,7 @@ def core_match_template_distributed(
             pixel_values=pixel_values,
             orientation_batch_size=orientation_batch_size,
             num_cuda_streams=num_cuda_streams,
+            backend=backend,
             device=device,
         )
     )

--- a/src/leopard_em/pydantic_models/managers/match_template_manager.py
+++ b/src/leopard_em/pydantic_models/managers/match_template_manager.py
@@ -240,6 +240,7 @@ class MatchTemplateManager(BaseModel2DTM):
             **core_kwargs,
             orientation_batch_size=orientation_batch_size,
             num_cuda_streams=self.computational_config.num_cpus,
+            backend=self.computational_config.backend,
         )
 
         # Populate the MatchTemplateResult via a private helper
@@ -307,6 +308,7 @@ class MatchTemplateManager(BaseModel2DTM):
             device,
             orientation_batch_size,
             self.computational_config.num_cpus,
+            self.computational_config.backend,
             **core_kwargs,
         )
 


### PR DESCRIPTION
User can specify streamed or batched for match tm in computational config.
Batched is >4x speed up for 1kx1k image. 